### PR TITLE
Implemented implicit padding for CRH inputs

### DIFF
--- a/src/poseidon/constraints.rs
+++ b/src/poseidon/constraints.rs
@@ -168,8 +168,8 @@ impl<F: PrimeField> AllocVar<PoseidonParameters<F>, F> for PoseidonParametersVar
 #[cfg(test)]
 mod test {
 	use super::*;
-	use ark_bls12_381::Fq;
 	use ark_crypto_primitives::crh::CRH as CRHTrait;
+	use ark_ed_on_bls12_381::Fq;
 	use ark_ff::{to_bytes, Zero};
 	use ark_relations::r1cs::ConstraintSystem;
 
@@ -207,7 +207,7 @@ mod test {
 		.unwrap();
 
 		// Test Poseidon on an input of 3 field elements. This will not require padding,
-		// since the inputs are aligned to the expected input chunk size of 48.
+		// since the inputs are aligned to the expected input chunk size of 32.
 		let aligned_inp = to_bytes![Fq::zero(), Fq::from(1u128), Fq::from(2u128)].unwrap();
 		let aligned_inp_var =
 			Vec::<UInt8<Fq>>::new_input(cs.clone(), || Ok(aligned_inp.clone())).unwrap();
@@ -221,7 +221,7 @@ mod test {
 		assert_eq!(res, res_var.value().unwrap());
 
 		// Test Poseidon on an input of 6 bytes. This will require padding, since the
-		// inputs are not aligned to the expected input chunk size of 48.
+		// inputs are not aligned to the expected input chunk size of 32.
 		let unaligned_inp: Vec<u8> = vec![1, 2, 3, 4, 5, 6];
 		let unaligned_inp_var =
 			Vec::<UInt8<Fq>>::new_input(cs.clone(), || Ok(unaligned_inp.clone())).unwrap();

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -24,7 +24,16 @@ use ark_relations::r1cs::SynthesisError;
 
 pub fn to_field_elements<F: PrimeField>(bytes: &[u8]) -> Result<Vec<F>, Error> {
 	let max_size_bytes = F::BigInt::NUM_LIMBS * 8;
-	let res = bytes
+
+	// Pad the input with zeros
+	let padding_len = (max_size_bytes - (bytes.len() % max_size_bytes)) % max_size_bytes;
+	let padded_input: Vec<u8> = bytes
+		.iter()
+		.cloned()
+		.chain(core::iter::repeat(0u8).take(padding_len))
+		.collect();
+
+	let res = padded_input
 		.chunks(max_size_bytes)
 		.map(|chunk| F::read(chunk))
 		.collect::<Result<Vec<_>, _>>()?;
@@ -36,7 +45,16 @@ pub fn to_field_var_elements<F: PrimeField>(
 	bytes: &[UInt8<F>],
 ) -> Result<Vec<FpVar<F>>, SynthesisError> {
 	let max_size = F::BigInt::NUM_LIMBS * 8;
-	let res = bytes
+
+	// Pad the input with zeros
+	let padding_len = (max_size - (bytes.len() % max_size)) % max_size;
+	let padded_input: Vec<UInt8<F>> = bytes
+		.iter()
+		.cloned()
+		.chain(core::iter::repeat(UInt8::constant(0u8)).take(padding_len))
+		.collect();
+
+	let res = padded_input
 		.chunks(max_size)
 		.map(|chunk| Boolean::le_bits_to_fp_var(chunk.to_bits_le()?.as_slice()))
 		.collect::<Result<Vec<_>, SynthesisError>>()?;
@@ -45,12 +63,10 @@ pub fn to_field_var_elements<F: PrimeField>(
 }
 
 pub fn from_field_elements<F: PrimeField>(elts: &[F]) -> Result<Vec<u8>, Error> {
-	let res = elts
-		.iter()
-		.fold(vec![], |mut acc, prev| {
-			acc.extend_from_slice(&prev.into_repr().to_bytes_le());
-			acc
-		});
+	let res = elts.iter().fold(vec![], |mut acc, prev| {
+		acc.extend_from_slice(&prev.into_repr().to_bytes_le());
+		acc
+	});
 
 	Ok(res)
 }


### PR DESCRIPTION
I ran into an error when using Poseidon. Namely, whenever I did `PoseidonCRH::evaluate` on a sequence of bytes whose length wasn't a multiple of 48, I'd get an error `Custom { kind: UnexpectedEof, error: "failed to fill whole buffer" }`. This comes from the `Fq::read` function when it doesn't get enough bytes to interpret its input as a field element.

I think it ought to be the case that `CRH::evaluate` work on byte sequences of arbitrary length, so I added a padding subroutine in the `to_field_elements` function (and corresponding ZK function), which are exclusively used in the Poseidon and Identity hash function preprocessing routines.

Let me know if this solution works for you or if you'd rather I go about it differently. Thanks for open sourcing this!