### PR TITLE
Add refund field to arbitrary inputs

### DIFF
--- a/src/arbitrary/bridge_data/mod.rs
+++ b/src/arbitrary/bridge_data/mod.rs
@@ -10,14 +10,16 @@ pub struct Input<F: PrimeField> {
 	pub recipient: F,
 	pub relayer: F,
 	pub fee: F,
+	pub refund: F,
 }
 
 impl<F: PrimeField> Input<F> {
-	pub fn new(recipient: F, relayer: F, fee: F) -> Self {
+	pub fn new(recipient: F, relayer: F, fee: F, refund: F) -> Self {
 		Self {
 			recipient,
 			relayer,
 			fee,
+			refund,
 		}
 	}
 }

--- a/src/circuit/bridge.rs
+++ b/src/circuit/bridge.rs
@@ -259,9 +259,10 @@ mod test {
 		let relayer = BlsFr::rand(rng);
 		let recipient = BlsFr::rand(rng);
 		let fee = BlsFr::rand(rng);
+		let refund = BlsFr::rand(rng);
 		let (leaf_private, leaf_public, leaf, nullifier_hash) = setup_leaf_x5(chain_id, &params5, rng);
 
-		let arbitrary_input = setup_arbitrary_data(recipient, relayer, fee);
+		let arbitrary_input = setup_arbitrary_data(recipient, relayer, fee, refund);
 		let params3 = setup_params_x5_3(curve);
 		let (_, path) = setup_tree_and_create_path_x5(&[leaf], 0, &params3);
 		let root = BlsFr::rand(rng);
@@ -304,9 +305,10 @@ mod test {
 		let relayer = BlsFr::rand(rng);
 		let recipient = BlsFr::rand(rng);
 		let fee = BlsFr::rand(rng);
+		let refund = BlsFr::rand(rng);
 		let (leaf_private, leaf_public, leaf, nullifier_hash) = setup_leaf_x5(chain_id, &params5, rng);
 
-		let arbitrary_input = setup_arbitrary_data(recipient, relayer, fee);
+		let arbitrary_input = setup_arbitrary_data(recipient, relayer, fee, refund);
 		let params3 = setup_params_x5_3(curve);
 		let (_, path) = setup_tree_and_create_path_x5(&[leaf], 0, &params3);
 		let root = BlsFr::rand(rng);
@@ -349,9 +351,10 @@ mod test {
 		let relayer = BlsFr::rand(rng);
 		let recipient = BlsFr::rand(rng);
 		let fee = BlsFr::rand(rng);
+		let refund = BlsFr::rand(rng);
 		let (leaf_private, leaf_public, _, nullifier_hash) = setup_leaf_x5(chain_id, &params5, rng);
 		let leaf = BlsFr::rand(rng);
-		let arbitrary_input = setup_arbitrary_data(recipient, relayer, fee);
+		let arbitrary_input = setup_arbitrary_data(recipient, relayer, fee, refund);
 		let params3 = setup_params_x5_3(curve);
 		let (_, path) = setup_tree_and_create_path_x5(&[leaf], 0, &params3);
 		let root = BlsFr::rand(rng);
@@ -394,9 +397,10 @@ mod test {
 		let relayer = BlsFr::rand(rng);
 		let recipient = BlsFr::rand(rng);
 		let fee = BlsFr::rand(rng);
+		let refund = BlsFr::rand(rng);
 		let (leaf_private, leaf_public, leaf, _) = setup_leaf_x5(chain_id, &params5, rng);
 		let nullifier_hash = BlsFr::rand(rng);
-		let arbitrary_input = setup_arbitrary_data(recipient, relayer, fee);
+		let arbitrary_input = setup_arbitrary_data(recipient, relayer, fee, refund);
 		let params3 = setup_params_x5_3(curve);
 		let (_, path) = setup_tree_and_create_path_x5(&[leaf], 0, &params3);
 		let root = BlsFr::rand(rng);

--- a/src/setup/bridge.rs
+++ b/src/setup/bridge.rs
@@ -98,8 +98,9 @@ pub fn setup_arbitrary_data<F: PrimeField>(
 	recipient: F,
 	relayer: F,
 	fee: F,
+	refund: F,
 ) -> BridgeConstraintDataInput<F> {
-	let arbitrary_input = BridgeConstraintDataInput::new(recipient, relayer, fee);
+	let arbitrary_input = BridgeConstraintDataInput::new(recipient, relayer, fee, refund);
 	arbitrary_input
 }
 
@@ -111,13 +112,14 @@ pub fn setup_circuit_x5<R: Rng, F: PrimeField>(
 	recipient: F,
 	relayer: F,
 	fee: F,
+	refund: F,
 	rng: &mut R,
 	curve: Curve,
 ) -> (Circuit_x5<F>, F, F, F, Vec<F>) {
 	let params3 = setup_params_x5_3::<F>(curve);
 	let params5 = setup_params_x5_5::<F>(curve);
 
-	let arbitrary_input = setup_arbitrary_data(recipient, relayer, fee);
+	let arbitrary_input = setup_arbitrary_data(recipient, relayer, fee, refund);
 	let (leaf_private, leaf_public, leaf, nullifier_hash) = setup_leaf_x5(chain_id, &params5, rng);
 	let mut leaves_new = leaves.to_vec();
 	leaves_new.push(leaf);
@@ -146,6 +148,7 @@ pub fn setup_circuit_x5<R: Rng, F: PrimeField>(
 		recipient,
 		relayer,
 		fee,
+		refund,
 	);
 	(mc, leaf, nullifier_hash, root, public_inputs)
 }
@@ -158,13 +161,14 @@ pub fn setup_circuit_x17<R: Rng, F: PrimeField>(
 	recipient: F,
 	relayer: F,
 	fee: F,
+	refund: F,
 	rng: &mut R,
 	curve: Curve,
 ) -> (Circuit_x5<F>, F, F, F, Vec<F>) {
 	let params3 = setup_params_x17_3::<F>(curve);
 	let params5 = setup_params_x17_5::<F>(curve);
 
-	let arbitrary_input = setup_arbitrary_data(recipient, relayer, fee);
+	let arbitrary_input = setup_arbitrary_data(recipient, relayer, fee, refund);
 	let (leaf_private, leaf_public, leaf, nullifier_hash) = setup_leaf_x5(chain_id, &params5, rng);
 	let mut leaves_new = leaves.to_vec();
 	leaves_new.push(leaf);
@@ -193,6 +197,7 @@ pub fn setup_circuit_x17<R: Rng, F: PrimeField>(
 		recipient,
 		relayer,
 		fee,
+		refund,
 	);
 	(mc, leaf, nullifier_hash, root, public_inputs)
 }
@@ -205,8 +210,9 @@ pub fn setup_random_circuit_x5<R: Rng, F: PrimeField>(rng: &mut R, curve: Curve)
 	let recipient = F::rand(rng);
 	let relayer = F::rand(rng);
 	let fee = F::rand(rng);
+	let refund = F::rand(rng);
 	setup_circuit_x5::<R, F>(
-		chain_id, &leaves, index, &roots, recipient, relayer, fee, rng, curve,
+		chain_id, &leaves, index, &roots, recipient, relayer, fee, refund, rng, curve,
 	)
 }
 
@@ -218,8 +224,9 @@ pub fn setup_random_circuit_x17<R: Rng, F: PrimeField>(rng: &mut R, curve: Curve
 	let recipient = F::rand(rng);
 	let relayer = F::rand(rng);
 	let fee = F::rand(rng);
+	let refund = F::rand(rng);
 	setup_circuit_x17::<R, F>(
-		chain_id, &leaves, index, &roots, recipient, relayer, fee, rng, curve,
+		chain_id, &leaves, index, &roots, recipient, relayer, fee, refund, rng, curve,
 	)
 }
 
@@ -231,6 +238,7 @@ pub fn get_public_inputs<F: PrimeField>(
 	recipient: F,
 	relayer: F,
 	fee: F,
+	refund: F,
 ) -> Vec<F> {
 	let mut public_inputs = Vec::new();
 	public_inputs.push(chain_id);
@@ -240,6 +248,7 @@ pub fn get_public_inputs<F: PrimeField>(
 	public_inputs.push(recipient);
 	public_inputs.push(relayer);
 	public_inputs.push(fee);
+	public_inputs.push(refund);
 	public_inputs
 }
 
@@ -322,10 +331,12 @@ mod test {
 		let recipient = Bls381::from(0u8);
 		let relayer = Bls381::from(0u8);
 		let fee = Bls381::from(0u8);
+		let refund = Bls381::from(0u8);
 		let leaves = Vec::new();
 		let roots = Vec::new();
+
 		let (circuit, leaf, nullifier, root, public_inputs) = setup_circuit_x5::<_, Bls381>(
-			chain_id, &leaves, 0, &roots, recipient, relayer, fee, &mut rng, curve,
+			chain_id, &leaves, 0, &roots, recipient, relayer, fee, refund, &mut rng, curve,
 		);
 
 		add_members_mock(vec![leaf]);
@@ -357,13 +368,15 @@ mod test {
 		let recipient = Bls381::from(0u8);
 		let relayer = Bls381::from(0u8);
 		let fee = Bls381::from(0u8);
+		let refund = Bls381::from(0u8);
 		let leaves = Vec::new();
 		let roots = Vec::new();
+
 
 		let params3 = setup_params_x5_3::<Bls381>(curve);
 		let params5 = setup_params_x5_5::<Bls381>(curve);
 
-		let arbitrary_input = setup_arbitrary_data::<Bls381>(recipient, relayer, fee);
+		let arbitrary_input = setup_arbitrary_data::<Bls381>(recipient, relayer, fee, refund);
 		let (leaf_private, leaf_public, leaf, nullifier_hash) =
 			setup_leaf_x5::<_, Bls381>(chain_id, &params5, &mut rng);
 		let mut leaves_new = leaves.to_vec();
@@ -393,6 +406,7 @@ mod test {
 			recipient,
 			relayer,
 			fee,
+			refund,
 		);
 
 		add_members_mock(vec![leaf]);
@@ -424,10 +438,12 @@ mod test {
 		let recipient = Bls381::from(0u8);
 		let relayer = Bls381::from(0u8);
 		let fee = Bls381::from(0u8);
+		let refund = Bls381::from(0u8);
 		let leaves = Vec::new();
 		let roots = Vec::new();
+
 		let (circuit, leaf, nullifier, root, public_inputs) = setup_circuit_x5::<_, Bls381>(
-			chain_id, &leaves, 0, &roots, recipient, relayer, fee, &mut rng, curve,
+			chain_id, &leaves, 0, &roots, recipient, relayer, fee, refund, &mut rng, curve,
 		);
 
 		add_members_mock(vec![leaf]);


### PR DESCRIPTION
This is a small update in the sequence of getting the bridge gadget implementation to be both secure and match the solidity/circom gadget.