### PR TITLE
remove `rho` from mixer leaf.

### DIFF
--- a/src/arbitrary/mixer_data/constraints.rs
+++ b/src/arbitrary/mixer_data/constraints.rs
@@ -62,7 +62,7 @@ impl<F: PrimeField> AllocVar<Input<F>, F> for InputVar<F> {
 		let recipient_var = FpVar::new_variable(cs.clone(), || Ok(&recipient), mode)?;
 		let relayer_var = FpVar::new_variable(cs.clone(), || Ok(&relayer), mode)?;
 		let fee_var = FpVar::new_variable(cs.clone(), || Ok(&fee), mode)?;
-		let refund_var = FpVar::new_variable(cs.clone(), || Ok(&refund), mode)?;
+		let refund_var = FpVar::new_variable(cs, || Ok(&refund), mode)?;
 
 		Ok(InputVar::new(
 			recipient_var,

--- a/src/leaf/basic/mod.rs
+++ b/src/leaf/basic/mod.rs
@@ -50,7 +50,10 @@ impl<F: PrimeField, H: CRH> LeafCreation<H> for BasicLeaf<F, H> {
 		H::evaluate(h, &bytes)
 	}
 
-	fn create_nullifier(s: &Self::Private, h: &H::Parameters) -> Result<Self::Nullifier, Error> {
+	fn create_nullifier_hash(
+		s: &Self::Private,
+		h: &H::Parameters,
+	) -> Result<Self::Nullifier, Error> {
 		let bytes = to_bytes![s.nullifier, s.nullifier]?;
 		H::evaluate(h, &bytes)
 	}

--- a/src/leaf/bridge/constraints.rs
+++ b/src/leaf/bridge/constraints.rs
@@ -229,7 +229,7 @@ mod test {
 		let public = Public::new(chain_id);
 		let secrets = Leaf::generate_secrets(rng).unwrap();
 		let leaf = Leaf::create_leaf(&secrets, &public, &params).unwrap();
-		let nullifier = Leaf::create_nullifier(&secrets, &params).unwrap();
+		let nullifier = Leaf::create_nullifier_hash(&secrets, &params).unwrap();
 
 		// Constraints version
 		let params_var = PoseidonParametersVar::new_variable(

--- a/src/leaf/bridge/mod.rs
+++ b/src/leaf/bridge/mod.rs
@@ -77,7 +77,10 @@ impl<F: PrimeField, H: CRH> LeafCreation<H> for BridgeLeaf<F, H> {
 		H::evaluate(h, &input_bytes)
 	}
 
-	fn create_nullifier(s: &Self::Private, h: &H::Parameters) -> Result<Self::Nullifier, Error> {
+	fn create_nullifier_hash(
+		s: &Self::Private,
+		h: &H::Parameters,
+	) -> Result<Self::Nullifier, Error> {
 		let nullifier_bytes = to_bytes![s.nullifier, s.nullifier]?;
 		H::evaluate(h, &nullifier_bytes)
 	}
@@ -129,7 +132,7 @@ mod test {
 		let nullifier_res = PoseidonCRH5::evaluate(&params, &nullifier_inputs).unwrap();
 
 		let leaf = Leaf::create_leaf(&secrets, &publics, &params).unwrap();
-		let nullifier_hash = Leaf::create_nullifier(&secrets, &params).unwrap();
+		let nullifier_hash = Leaf::create_nullifier_hash(&secrets, &params).unwrap();
 		assert_eq!(leaf_res, leaf);
 		assert_eq!(nullifier_res, nullifier_hash);
 	}

--- a/src/leaf/mod.rs
+++ b/src/leaf/mod.rs
@@ -23,5 +23,8 @@ pub trait LeafCreation<H: CRH>: Sized {
 		p: &Self::Public,
 		h: &H::Parameters,
 	) -> Result<Self::Leaf, Error>;
-	fn create_nullifier(s: &Self::Private, h: &H::Parameters) -> Result<Self::Nullifier, Error>;
+	fn create_nullifier_hash(
+		s: &Self::Private,
+		h: &H::Parameters,
+	) -> Result<Self::Nullifier, Error>;
 }

--- a/src/setup/bridge.rs
+++ b/src/setup/bridge.rs
@@ -162,7 +162,7 @@ macro_rules! impl_setup_bridge_leaf {
 
 				// Creating the leaf
 				let leaf = $leaf_ty::create_leaf(&leaf_private, &leaf_public, params).unwrap();
-				let nullifier_hash = $leaf_ty::create_nullifier(&leaf_private, params).unwrap();
+				let nullifier_hash = $leaf_ty::create_nullifier_hash(&leaf_private, params).unwrap();
 				(leaf_private, leaf_public, leaf, nullifier_hash)
 			}
 		}

--- a/src/setup/mixer.rs
+++ b/src/setup/mixer.rs
@@ -140,7 +140,7 @@ macro_rules! impl_setup_mixer_leaf {
 
 				// Creating the leaf
 				let leaf = $leaf_ty::create_leaf(&leaf_private, &(), params).unwrap();
-				let nullifier_hash = $leaf_ty::create_nullifier(&leaf_private, params).unwrap();
+				let nullifier_hash = $leaf_ty::create_nullifier_hash(&leaf_private, params).unwrap();
 				(leaf_private, leaf, nullifier_hash)
 			}
 		}


### PR DESCRIPTION
This removes `rho` from the Mixer leaf, also renames some functions:

`r` -> `secret`
`create_nullifier` -> `create_nullifier_hash`.

There is a following PR update for the `MerkleTree` `Zerohash` value to be configurable instead of being a fixed value.

**SO, DO NOT PUBLISH A NEW VERSION NOW.**