### PR TITLE
Made Poseidon::permute public

### DIFF
--- a/arkworks-gadgets/src/poseidon/constraints.rs
+++ b/arkworks-gadgets/src/poseidon/constraints.rs
@@ -72,7 +72,7 @@ impl<F: PrimeField> AllocVar<PoseidonParameters<F>, F> for PoseidonParametersVar
 pub struct CRHGadget<F: PrimeField>(PhantomData<F>);
 
 impl<F: PrimeField> CRHGadget<F> {
-	fn permute(
+	pub fn permute(
 		params: &PoseidonParametersVar<F>,
 		mut state: Vec<FpVar<F>>,
 	) -> Result<Vec<FpVar<F>>, SynthesisError> {

--- a/arkworks-gadgets/src/poseidon/mod.rs
+++ b/arkworks-gadgets/src/poseidon/mod.rs
@@ -9,7 +9,10 @@ pub mod constraints;
 pub struct CRH<F: PrimeField>(PhantomData<F>);
 
 impl<F: PrimeField> CRH<F> {
-	fn permute(params: &PoseidonParameters<F>, mut state: Vec<F>) -> Result<Vec<F>, PoseidonError> {
+	pub fn permute(
+		params: &PoseidonParameters<F>,
+		mut state: Vec<F>,
+	) -> Result<Vec<F>, PoseidonError> {
 		let nr = (params.full_rounds + params.partial_rounds) as usize;
 		for r in 0..nr {
 			state.iter_mut().enumerate().for_each(|(i, a)| {


### PR DESCRIPTION
I needed this for an optimized usecase. The `CRHTrait::evaluate` and `CRHGadgetTrait::evaluate` take in bytes and then convert them to field elements. In my use case, I already have field elements, so the round trip is unnecessary. Worse, this is in my hot path so I need every optimization I can get.