### PR TITLE
Todd/arithmetic gate fix

### DIFF
--- a/arkworks-plonk-circuits/Cargo.toml
+++ b/arkworks-plonk-circuits/Cargo.toml
@@ -15,7 +15,7 @@ arkworks-utils = {path = "../arkworks-utils",  version = "0.4.0"}
 ark-crypto-primitives = { version = "^0.3.0", features = ["r1cs"], default-features = false }
 ark-ff = { version = "^0.3.0", default-features = false }
 ark-std = { version = "^0.3.0", default-features = false }
-ark-plonk = { version = "^0.8", git = "https://github.com/rust-zkp/ark-plonk", default-features = false }
+ark-plonk = { version = "^0.8", git = "https://github.com/ZK-Garage/plonk", default-features = false }
 
 ark-poly-commit = { version = "^0.3.0", default-features = false }
 ark-poly = { version = "^0.3.0", default-features = false }

--- a/arkworks-plonk-circuits/src/poseidon/sbox.rs
+++ b/arkworks-plonk-circuits/src/poseidon/sbox.rs
@@ -1,4 +1,4 @@
-use ark_ec::{PairingEngine, TEModelParameters};
+use ark_ec::{PairingEngine, TEModelParameters, AffineCurve};
 use ark_ff::Field;
 use ark_plonk::{constraint_system::StandardComposer, error::Error, prelude::Variable};
 use ark_std::{One, Zero};
@@ -92,8 +92,14 @@ fn synthesize_exp3_sbox<E: PairingEngine, P: TEModelParameters<BaseField = E::Fr
 	input_var: &Variable,
 	composer: &mut StandardComposer<E, P>,
 ) -> Result<Variable, Error> {
-	let sqr = composer.mul(E::Fr::one(), *input_var, *input_var, E::Fr::zero(), None);
-	let cube = composer.mul(E::Fr::one(), sqr, *input_var, E::Fr::zero(), None);
+	// let sqr = composer.mul(E::Fr::one(), *input_var, *input_var, E::Fr::zero(), None);
+	let sqr = composer.arithmetic_gate(|gate| {
+		gate.witness(*input_var, *input_var, None).mul(E::Fr::one())
+	});
+	// let cube = composer.mul(E::Fr::one(), sqr, *input_var, E::Fr::zero(), None);
+	let cube = composer.arithmetic_gate(|gate| {
+		gate.witness(sqr, *input_var, None).mul(E::Fr::one())
+	});
 	Ok(cube)
 }
 
@@ -102,9 +108,18 @@ fn synthesize_exp5_sbox<E: PairingEngine, P: TEModelParameters<BaseField = E::Fr
 	input_var: &Variable,
 	composer: &mut StandardComposer<E, P>,
 ) -> Result<Variable, Error> {
-	let sqr = composer.mul(E::Fr::one(), *input_var, *input_var, E::Fr::zero(), None);
-	let fourth = composer.mul(E::Fr::one(), sqr, sqr, E::Fr::zero(), None);
-	let fifth = composer.mul(E::Fr::one(), fourth, *input_var, E::Fr::zero(), None);
+	// let sqr = composer.mul(E::Fr::one(), *input_var, *input_var, E::Fr::zero(), None);
+	let sqr = composer.arithmetic_gate(|gate| {
+		gate.witness(*input_var, *input_var, None).mul(E::Fr::one())
+	});
+	// let fourth = composer.mul(E::Fr::one(), sqr, sqr, E::Fr::zero(), None);
+	let fourth = composer.arithmetic_gate(|gate| {
+		gate.witness(sqr, sqr, None).mul(E::Fr::one())
+	});
+	// let fifth = composer.mul(E::Fr::one(), fourth, *input_var, E::Fr::zero(), None);
+	let fifth = composer.arithmetic_gate(|gate| {
+		gate.witness(fourth, *input_var, None).mul(E::Fr::one())
+	});
 	Ok(fifth)
 }
 
@@ -113,10 +128,25 @@ fn synthesize_exp17_sbox<E: PairingEngine, P: TEModelParameters<BaseField = E::F
 	input_var: &Variable,
 	composer: &mut StandardComposer<E, P>,
 ) -> Result<Variable, Error> {
-	let sqr = composer.mul(E::Fr::one(), *input_var, *input_var, E::Fr::zero(), None);
-	let fourth = composer.mul(E::Fr::one(), sqr, sqr, E::Fr::zero(), None);
-	let eigth = composer.mul(E::Fr::one(), fourth, fourth, E::Fr::zero(), None);
-	let sixteenth = composer.mul(E::Fr::one(), eigth, eigth, E::Fr::zero(), None);
-	let seventeenth = composer.mul(E::Fr::one(), sixteenth, *input_var, E::Fr::zero(), None);
+	// let sqr = composer.mul(E::Fr::one(), *input_var, *input_var, E::Fr::zero(), None);
+	let sqr = composer.arithmetic_gate(|gate| {
+		gate.witness(*input_var, *input_var, None).mul(E::Fr::one())
+	});
+	// let fourth = composer.mul(E::Fr::one(), sqr, sqr, E::Fr::zero(), None);
+	let fourth = composer.arithmetic_gate(|gate| {
+		gate.witness(sqr, sqr, None).mul(E::Fr::one())
+	});
+	// let eigth = composer.mul(E::Fr::one(), fourth, fourth, E::Fr::zero(), None);
+	let eigth = composer.arithmetic_gate(|gate| {
+		gate.witness(fourth, fourth, None).mul(E::Fr::one())
+	});
+	// let sixteenth = composer.mul(E::Fr::one(), eigth, eigth, E::Fr::zero(), None);
+	let sixteenth = composer.arithmetic_gate(|gate| {
+		gate.witness(eigth, eigth, None).mul(E::Fr::one())
+	});
+	// let seventeenth = composer.mul(E::Fr::one(), sixteenth, *input_var, E::Fr::zero(), None);
+	let seventeenth = composer.arithmetic_gate(|gate| {
+		gate.witness(sixteenth, *input_var, None).mul(E::Fr::one())
+	});
 	Ok(seventeenth)
 }

--- a/arkworks-plonk-circuits/src/poseidon/sbox.rs
+++ b/arkworks-plonk-circuits/src/poseidon/sbox.rs
@@ -92,11 +92,9 @@ fn synthesize_exp3_sbox<E: PairingEngine, P: TEModelParameters<BaseField = E::Fr
 	input_var: &Variable,
 	composer: &mut StandardComposer<E, P>,
 ) -> Result<Variable, Error> {
-	// let sqr = composer.mul(E::Fr::one(), *input_var, *input_var, E::Fr::zero(), None);
 	let sqr = composer.arithmetic_gate(|gate| {
 		gate.witness(*input_var, *input_var, None).mul(E::Fr::one())
 	});
-	// let cube = composer.mul(E::Fr::one(), sqr, *input_var, E::Fr::zero(), None);
 	let cube = composer.arithmetic_gate(|gate| {
 		gate.witness(sqr, *input_var, None).mul(E::Fr::one())
 	});
@@ -108,15 +106,12 @@ fn synthesize_exp5_sbox<E: PairingEngine, P: TEModelParameters<BaseField = E::Fr
 	input_var: &Variable,
 	composer: &mut StandardComposer<E, P>,
 ) -> Result<Variable, Error> {
-	// let sqr = composer.mul(E::Fr::one(), *input_var, *input_var, E::Fr::zero(), None);
 	let sqr = composer.arithmetic_gate(|gate| {
 		gate.witness(*input_var, *input_var, None).mul(E::Fr::one())
 	});
-	// let fourth = composer.mul(E::Fr::one(), sqr, sqr, E::Fr::zero(), None);
 	let fourth = composer.arithmetic_gate(|gate| {
 		gate.witness(sqr, sqr, None).mul(E::Fr::one())
 	});
-	// let fifth = composer.mul(E::Fr::one(), fourth, *input_var, E::Fr::zero(), None);
 	let fifth = composer.arithmetic_gate(|gate| {
 		gate.witness(fourth, *input_var, None).mul(E::Fr::one())
 	});
@@ -128,23 +123,18 @@ fn synthesize_exp17_sbox<E: PairingEngine, P: TEModelParameters<BaseField = E::F
 	input_var: &Variable,
 	composer: &mut StandardComposer<E, P>,
 ) -> Result<Variable, Error> {
-	// let sqr = composer.mul(E::Fr::one(), *input_var, *input_var, E::Fr::zero(), None);
 	let sqr = composer.arithmetic_gate(|gate| {
 		gate.witness(*input_var, *input_var, None).mul(E::Fr::one())
 	});
-	// let fourth = composer.mul(E::Fr::one(), sqr, sqr, E::Fr::zero(), None);
 	let fourth = composer.arithmetic_gate(|gate| {
 		gate.witness(sqr, sqr, None).mul(E::Fr::one())
 	});
-	// let eigth = composer.mul(E::Fr::one(), fourth, fourth, E::Fr::zero(), None);
 	let eigth = composer.arithmetic_gate(|gate| {
 		gate.witness(fourth, fourth, None).mul(E::Fr::one())
 	});
-	// let sixteenth = composer.mul(E::Fr::one(), eigth, eigth, E::Fr::zero(), None);
 	let sixteenth = composer.arithmetic_gate(|gate| {
 		gate.witness(eigth, eigth, None).mul(E::Fr::one())
 	});
-	// let seventeenth = composer.mul(E::Fr::one(), sixteenth, *input_var, E::Fr::zero(), None);
 	let seventeenth = composer.arithmetic_gate(|gate| {
 		gate.witness(sixteenth, *input_var, None).mul(E::Fr::one())
 	});

--- a/arkworks-plonk-circuits/src/set_membership/mod.rs
+++ b/arkworks-plonk-circuits/src/set_membership/mod.rs
@@ -22,19 +22,26 @@ impl<E: PairingEngine, P: TEModelParameters<BaseField = E::Fr>> Circuit<E, P>
 
 		let mut diffs = Vec::new();
 		for x in roots {
-			let diff = composer.add(
-				(-E::Fr::one(), target),
-				(E::Fr::one(), x),
-				E::Fr::zero(),
-				None,
-			);
+			// let diff = composer.add(
+			// 	(-E::Fr::one(), target),
+			// 	(E::Fr::one(), x),
+			// 	E::Fr::zero(),
+			// 	None,
+			// );
+			let diff = composer.arithmetic_gate(|gate| {
+				gate.witness(target, x, None)
+				.add(-E::Fr::one(), E::Fr::one())
+			});
 			diffs.push(diff);
 		}
 
 		let mut sum = composer.add_input(E::Fr::one());
 
 		for diff in diffs {
-			sum = composer.mul(E::Fr::one(), sum, diff, E::Fr::zero(), None);
+			// sum = composer.mul(E::Fr::one(), sum, diff, E::Fr::zero(), None);
+			sum = composer.arithmetic_gate(|gate| {
+				gate.witness(sum, diff, None).mul(E::Fr::one())
+			});
 		}
 
 		composer.assert_equal(sum, composer.zero_var());

--- a/arkworks-plonk-circuits/src/set_membership/mod.rs
+++ b/arkworks-plonk-circuits/src/set_membership/mod.rs
@@ -22,12 +22,6 @@ impl<E: PairingEngine, P: TEModelParameters<BaseField = E::Fr>> Circuit<E, P>
 
 		let mut diffs = Vec::new();
 		for x in roots {
-			// let diff = composer.add(
-			// 	(-E::Fr::one(), target),
-			// 	(E::Fr::one(), x),
-			// 	E::Fr::zero(),
-			// 	None,
-			// );
 			let diff = composer.arithmetic_gate(|gate| {
 				gate.witness(target, x, None)
 				.add(-E::Fr::one(), E::Fr::one())
@@ -38,7 +32,6 @@ impl<E: PairingEngine, P: TEModelParameters<BaseField = E::Fr>> Circuit<E, P>
 		let mut sum = composer.add_input(E::Fr::one());
 
 		for diff in diffs {
-			// sum = composer.mul(E::Fr::one(), sum, diff, E::Fr::zero(), None);
 			sum = composer.arithmetic_gate(|gate| {
 				gate.witness(sum, diff, None).mul(E::Fr::one())
 			});


### PR DESCRIPTION
Arithmetic gates have been changed by the latest ark-plonk update.  Whereas one used to use composer.add(...) composer.mul(...) we now use composer.arithmetic\_gate(...) and specify a new ArithmeticGate struct.  

Also poseidon.rs previously ran a width-5 test that does not make sense to run, so that was removed.