### PR TITLE
plonk path gadgets

### DIFF
--- a/arkworks-gadgets/src/merkle_tree/simple_merkle.rs
+++ b/arkworks-gadgets/src/merkle_tree/simple_merkle.rs
@@ -10,7 +10,7 @@ use ark_std::{
 // Path
 #[derive(Clone)]
 pub struct Path<F: PrimeField, H: FieldHasher<F>, const N: usize> {
-	pub(crate) path: [(F, F); N],
+	pub path: [(F, F); N],
 	_marker: PhantomData<H>,
 }
 

--- a/arkworks-gadgets/src/merkle_tree/simple_merkle.rs
+++ b/arkworks-gadgets/src/merkle_tree/simple_merkle.rs
@@ -2,8 +2,10 @@ use super::{is_left_child, is_root, left_child, parent, right_child, sibling, tr
 use crate::poseidon::field_hasher::FieldHasher;
 use ark_crypto_primitives::Error;
 use ark_ff::PrimeField;
-use ark_std::collections::BTreeMap;
-use ark_std::{collections::BTreeSet, marker::PhantomData};
+use ark_std::{
+	collections::{BTreeMap, BTreeSet},
+	marker::PhantomData,
+};
 
 // Path
 #[derive(Clone)]

--- a/arkworks-gadgets/src/merkle_tree/simple_merkle.rs
+++ b/arkworks-gadgets/src/merkle_tree/simple_merkle.rs
@@ -3,7 +3,7 @@ use crate::poseidon::field_hasher::FieldHasher;
 use ark_crypto_primitives::Error;
 use ark_ff::PrimeField;
 use ark_std::collections::BTreeMap;
-use std::{collections::BTreeSet, marker::PhantomData};
+use ark_std::{collections::BTreeSet, marker::PhantomData};
 
 // Path
 #[derive(Clone)]

--- a/arkworks-plonk-circuits/Cargo.toml
+++ b/arkworks-plonk-circuits/Cargo.toml
@@ -26,6 +26,7 @@ ark-serialize = {version = "^0.3.0", default-features = false }
 ark-ed-on-bn254 = { version = "^0.3.0", default-features = false, features = [ "r1cs" ] }
 ark-bn254 = { version = "^0.3.0", default-features = false, features = [ "curve" ] }
 arkworks-gadgets = {path = "../arkworks-gadgets",  version = "0.4.0", default-features = false }
+ark-bls12-381 = { version = "^0.3.0", default-features = false, features = [ "curve" ] }
 
 [features]
 default = ["std"]

--- a/arkworks-plonk-circuits/src/lib.rs
+++ b/arkworks-plonk-circuits/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+pub mod merkle_tree;
 pub mod poseidon;
 pub mod set_membership;

--- a/arkworks-plonk-circuits/src/merkle_tree/mod.rs
+++ b/arkworks-plonk-circuits/src/merkle_tree/mod.rs
@@ -177,7 +177,8 @@ mod test {
 			let root_var = composer.add_input(root);
 			let leaf_var = composer.add_input(self.leaves[0]);
 
-			let res = path_gadget.check_membership(composer, &root_var, &leaf_var, &hasher_gadget)?;
+			let res =
+				path_gadget.check_membership(composer, &root_var, &leaf_var, &hasher_gadget)?;
 			let one = composer.add_input(F::one());
 			composer.assert_equal(res, one);
 

--- a/arkworks-plonk-circuits/src/merkle_tree/mod.rs
+++ b/arkworks-plonk-circuits/src/merkle_tree/mod.rs
@@ -69,12 +69,17 @@ impl<
 		leaf: &Variable,
 		hash_gadget: &HG,
 	) -> Result<Variable, Error> {
-		// Check if leaf is one of the bottom-most siblings
-		let leaf_is_left = composer.is_eq_with_output(leaf_hash, self.path[0].0);
-		composer.assert_equal(
-			*leaf,
-			composer.conditional_select(leaf_is_left, self.path[0].0, self.path[0].0),
-		);
+		// The old version of this in merkle_tree::constraints.rs contains the following check
+		// at the beginning: but it seems redundant because this will be checked in the for loop below
+		// Am I missing something? Investigate in tests...
+
+		// // Check if leaf is one of the bottom-most siblings
+		// let leaf_is_left = composer.is_eq_with_output(leaf_hash, self.path[0].0);
+		// composer.assert_equal(
+		// 	*leaf,
+		// 	composer.conditional_select(leaf_is_left, self.path[0].0, self.path[0].1),
+		// );
+
 
 		// Check levels between leaf level and root
 		let mut previous_hash = *leaf;

--- a/arkworks-plonk-circuits/src/merkle_tree/mod.rs
+++ b/arkworks-plonk-circuits/src/merkle_tree/mod.rs
@@ -1,12 +1,8 @@
-use std::marker::PhantomData;
-
-use crate::poseidon::poseidon::{FieldHasherGadget, PoseidonParametersVar};
+use crate::poseidon::poseidon::FieldHasherGadget;
 use ark_ec::models::TEModelParameters;
 use ark_ff::PrimeField;
-use arkworks_gadgets::{
-	merkle_tree::simple_merkle::{Path, SparseMerkleTree},
-	poseidon::field_hasher::Poseidon,
-};
+use ark_std::marker::PhantomData;
+use arkworks_gadgets::merkle_tree::simple_merkle::Path;
 use plonk::{constraint_system::StandardComposer, error::Error, prelude::Variable};
 
 #[derive(Clone)]
@@ -16,7 +12,7 @@ pub struct PathVar<
 	HG: FieldHasherGadget<F, P>,
 	const N: usize,
 > {
-	path: [(Variable, Variable); N], // Or should we use Vec< ...> ?
+	path: [(Variable, Variable); N],
 	_field: PhantomData<F>,
 	_te: PhantomData<P>,
 	_hg: PhantomData<HG>,
@@ -48,7 +44,6 @@ impl<
 		}
 	}
 
-	// Should this really have output?
 	pub fn check_membership(
 		&self,
 		composer: &mut StandardComposer<F, P>,
@@ -56,7 +51,7 @@ impl<
 		leaf: &Variable,
 		hasher: &HG,
 	) -> Result<Variable, Error> {
-		let computed_root = self.calculate_root(composer, leaf, hash_gadget)?;
+		let computed_root = self.calculate_root(composer, leaf, hasher)?;
 
 		composer.assert_equal(computed_root, *root_hash);
 
@@ -69,26 +64,15 @@ impl<
 		leaf: &Variable,
 		hash_gadget: &HG,
 	) -> Result<Variable, Error> {
-		// The old version of this in merkle_tree::constraints.rs contains the following
-		// check at the beginning: but it seems redundant because this will be checked
-		// in the for loop below Am I missing something? Investigate in tests...
-
-		// // Check if leaf is one of the bottom-most siblings
-		// let leaf_is_left = composer.is_eq_with_output(leaf_hash, self.path[0].0);
-		// composer.assert_equal(
-		// 	*leaf,
-		// 	composer.conditional_select(leaf_is_left, self.path[0].0, self.path[0].1),
-		// );
-
 		// Check levels between leaf level and root
 		let mut previous_hash = *leaf;
+
 		for (left_hash, right_hash) in self.path.iter() {
 			// Check if previous_hash matches the correct current hash
 			let previous_is_left = composer.is_eq_with_output(previous_hash, *left_hash);
-			composer.assert_equal(
-				previous_hash,
-				composer.conditional_select(previous_is_left, *left_hash, *right_hash),
-			);
+			let left_or_right =
+				composer.conditional_select(previous_is_left, *left_hash, *right_hash);
+			composer.assert_equal(previous_hash, left_or_right);
 
 			// Update previous_hash
 			previous_hash = hash_gadget.hash_two(composer, left_hash, right_hash)?;
@@ -101,36 +85,114 @@ impl<
 #[cfg(test)]
 mod test {
 	use super::PathVar;
-	use crate::poseidon::poseidon::{FieldHasherGadget, PoseidonParametersVar};
-	use ark_bls12_381::Fr as BlsFr;
+	use crate::poseidon::poseidon::{FieldHasherGadget, PoseidonGadget};
+	use ark_bn254::{Bn254, Fr as Bn254Fr};
+	use ark_ec::TEModelParameters;
+	use ark_ed_on_bn254::{EdwardsParameters as JubjubParameters, Fq};
 	use ark_ff::PrimeField;
+	use ark_poly::polynomial::univariate::DensePolynomial;
+	use ark_poly_commit::{kzg10::UniversalParams, sonic_pc::SonicKZG10, PolynomialCommitment};
 	use ark_std::test_rng;
 	use arkworks_gadgets::{
-		merkle_tree::simple_merkle::{Path, SparseMerkleTree},
+		ark_std::UniformRand, merkle_tree::simple_merkle::SparseMerkleTree,
 		poseidon::field_hasher::Poseidon,
 	};
 	use arkworks_utils::utils::common::{setup_params_x5_3, Curve};
-	use plonk::{constraint_system::StandardComposer, error::Error, prelude::Variable};
+	use plonk::prelude::*;
 
-	type PoseidonBLS = Poseidon<BlsFr>;
-	type SMTBls = SparseMerkleTree<BlsFr, PoseidonBLS, 3usize>;
+	type PoseidonBn254 = Poseidon<Fq>;
+
+	struct TestCircuit<
+		'a,
+		F: PrimeField,
+		P: TEModelParameters<BaseField = F>,
+		HG: FieldHasherGadget<F, P>,
+		const N: usize,
+	> {
+		leaves: &'a [F],
+		empty_leaf: &'a [u8],
+		hasher: &'a HG::Native,
+	}
+
+	impl<
+			F: PrimeField,
+			P: TEModelParameters<BaseField = F>,
+			HG: FieldHasherGadget<F, P>,
+			const N: usize,
+		> Circuit<F, P> for TestCircuit<'_, F, P, HG, N>
+	{
+		const CIRCUIT_ID: [u8; 32] = [0xfe; 32];
+
+		fn gadget(&mut self, composer: &mut StandardComposer<F, P>) -> Result<(), Error> {
+			let hasher_gadget = HG::from_native(composer, self.hasher.clone());
+
+			let smt = SparseMerkleTree::<F, HG::Native, N>::new_sequential(
+				self.leaves,
+				&self.hasher,
+				self.empty_leaf,
+			)
+			.unwrap();
+			let root = smt.root();
+			let path = smt.generate_membership_proof(0);
+
+			let path_var = PathVar::<F, P, HG, N>::from_native(composer, path);
+			let root_var = composer.add_input(root);
+			let leaf_var = composer.add_input(self.leaves[0]);
+
+			let res = path_var.check_membership(composer, &root_var, &leaf_var, &hasher_gadget)?;
+			let one = composer.add_input(F::one());
+			composer.assert_equal(res, one);
+
+			Ok(())
+		}
+
+		fn padded_circuit_size(&self) -> usize {
+			1 << 13
+		}
+	}
 
 	#[test]
 	fn should_verify_path() {
 		let rng = &mut test_rng();
-		let curve = Curve::Bls381;
+		let curve = Curve::Bn254;
 
 		let params = setup_params_x5_3(curve);
+		let poseidon = PoseidonBn254 { params };
 
-		let poseidon = PoseidonBLS { params };
-
-		let leaves = [BlsFr::rand(rng), BlsFr::rand(rng), BlsFr::rand(rng)];
+		let leaves = [Fq::rand(rng), Fq::rand(rng), Fq::rand(rng)];
 		let empty_leaf = [0u8; 32];
-		let smt = SMTBls::new_sequential(leaves, &poseidon, &empty_leaf)?;
-		let root = smt.root();
-		let path = smt.generate_membership_proof(0);
 
-		let mut composer = StandardComposer::new();
-		let path_var = PathVar::from_native(&composer, path);
+		// Create the test circuit
+		let mut test_circuit = TestCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, 3usize> {
+			leaves: &leaves,
+			empty_leaf: &empty_leaf,
+			hasher: &poseidon,
+		};
+
+		// Usual prover/verifier flow:
+		let u_params: UniversalParams<Bn254> =
+			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 14, None, rng).unwrap();
+
+		let (pk, vd) = test_circuit
+			.compile::<SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>>(&u_params)
+			.unwrap();
+
+		// PROVER
+		let proof = test_circuit.gen_proof(&u_params, pk, b"SMT Test").unwrap();
+
+		// VERIFIER
+		let public_inputs: Vec<PublicInputValue<Bn254Fr>> = vec![];
+
+		let VerifierData { key, pi_pos } = vd;
+
+		circuit::verify_proof::<_, JubjubParameters, _>(
+			&u_params,
+			key,
+			&proof,
+			&public_inputs,
+			&pi_pos,
+			b"SMT Test",
+		)
+		.unwrap();
 	}
 }

--- a/arkworks-plonk-circuits/src/merkle_tree/mod.rs
+++ b/arkworks-plonk-circuits/src/merkle_tree/mod.rs
@@ -170,8 +170,8 @@ mod test {
 				self.empty_leaf,
 			)
 			.unwrap();
-			let root = smt.root();
 			let path = smt.generate_membership_proof(0);
+			let root = path.calculate_root(&self.leaves[0], &self.hasher).unwrap();
 
 			let path_var = PathVar::<F, P, HG, N>::from_native(composer, path);
 			let root_var = composer.add_input(root);

--- a/arkworks-plonk-circuits/src/merkle_tree/mod.rs
+++ b/arkworks-plonk-circuits/src/merkle_tree/mod.rs
@@ -69,9 +69,9 @@ impl<
 		leaf: &Variable,
 		hash_gadget: &HG,
 	) -> Result<Variable, Error> {
-		// The old version of this in merkle_tree::constraints.rs contains the following check
-		// at the beginning: but it seems redundant because this will be checked in the for loop below
-		// Am I missing something? Investigate in tests...
+		// The old version of this in merkle_tree::constraints.rs contains the following
+		// check at the beginning: but it seems redundant because this will be checked
+		// in the for loop below Am I missing something? Investigate in tests...
 
 		// // Check if leaf is one of the bottom-most siblings
 		// let leaf_is_left = composer.is_eq_with_output(leaf_hash, self.path[0].0);
@@ -80,14 +80,13 @@ impl<
 		// 	composer.conditional_select(leaf_is_left, self.path[0].0, self.path[0].1),
 		// );
 
-
 		// Check levels between leaf level and root
 		let mut previous_hash = *leaf;
 		for (left_hash, right_hash) in self.path.iter() {
 			// Check if previous_hash matches the correct current hash
 			let previous_is_left = composer.is_eq_with_output(previous_hash, *left_hash);
 			composer.assert_equal(
-				previoush_hash,
+				previous_hash,
 				composer.conditional_select(previous_is_left, *left_hash, *right_hash),
 			);
 
@@ -96,5 +95,42 @@ impl<
 		}
 
 		Ok(previous_hash)
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::PathVar;
+	use crate::poseidon::poseidon::{FieldHasherGadget, PoseidonParametersVar};
+	use ark_bls12_381::Fr as BlsFr;
+	use ark_ff::PrimeField;
+	use ark_std::test_rng;
+	use arkworks_gadgets::{
+		merkle_tree::simple_merkle::{Path, SparseMerkleTree},
+		poseidon::field_hasher::Poseidon,
+	};
+	use arkworks_utils::utils::common::{setup_params_x5_3, Curve};
+	use plonk::{constraint_system::StandardComposer, error::Error, prelude::Variable};
+
+	type PoseidonBLS = Poseidon<BlsFr>;
+	type SMTBls = SparseMerkleTree<BlsFr, PoseidonBLS, 3usize>;
+
+	#[test]
+	fn should_verify_path() {
+		let rng = &mut test_rng();
+		let curve = Curve::Bls381;
+
+		let params = setup_params_x5_3(curve);
+
+		let poseidon = PoseidonBLS { params };
+
+		let leaves = [BlsFr::rand(rng), BlsFr::rand(rng), BlsFr::rand(rng)];
+		let empty_leaf = [0u8; 32];
+		let smt = SMTBls::new_sequential(leaves, &poseidon, &empty_leaf)?;
+		let root = smt.root();
+		let path = smt.generate_membership_proof(0);
+
+		let mut composer = StandardComposer::new();
+		let path_var = PathVar::from_native(&composer, path);
 	}
 }

--- a/arkworks-plonk-circuits/src/merkle_tree/mod.rs
+++ b/arkworks-plonk-circuits/src/merkle_tree/mod.rs
@@ -1,0 +1,75 @@
+use std::{marker::PhantomData};
+
+use crate::poseidon::poseidon::{FieldHasherGadget, PoseidonParametersVar};
+use ark_ec::{models::TEModelParameters, PairingEngine};
+use ark_ff::PrimeField;
+use arkworks_gadgets::{
+	merkle_tree::simple_merkle::{Path, SparseMerkleTree},
+	poseidon::field_hasher::Poseidon,
+};
+use plonk::{constraint_system::StandardComposer, error::Error, prelude::Variable};
+
+#[derive(Clone)]
+pub struct PathVar<
+	E: PairingEngine,
+	P: TEModelParameters<BaseField = E::Fr>,
+	HG: FieldHasherGadget<E, P>,
+	const N: usize,
+> {
+	path: [(Variable, Variable); N], // Or should we use Vec< ...> ?
+	_engine: PhantomData<E>,
+	_te: PhantomData<P>,
+	_hg: PhantomData<HG>,
+}
+
+impl<
+		E: PairingEngine,
+		P: TEModelParameters<BaseField = E::Fr>,
+		HG: FieldHasherGadget<E, P>,
+		const N: usize,
+	> PathVar<E, P, HG, N>
+{
+	fn from_native(composer: &mut StandardComposer<E, P>, native: Path<F, HG::Native, N>) -> Self {
+		// Initialize the array
+		let mut path_vars = [(composer.zero_var(), composer.zero_var()); N];
+
+		for i in 0..N {
+			path_vars[i] = (
+				composer.add_input(native.path[i].0),
+				composer.add_input(native.path[i].1),
+			);
+		}
+
+		PathVar {
+			path: path_vars,
+			_engine: PhantomData,
+			_te: PhantomData,
+			_hg: PhantomData,
+		}
+	}
+
+	pub fn check_membership(
+		&self,
+		composer: &mut StandardComposer<E, P>,
+		root_hash: &Variable,
+		leaf: &Variable,
+		hasher: &HG,
+	) -> Result<Variable, Error> {
+		Ok(composer.zero_var())
+	}
+
+	pub fn calculate_root(
+		&self,
+		composer: &mut StandardComposer<E, P>,
+		leaf: &Variable,
+        hash_gadget: &HG, 
+	) -> Result<Variable, Error> {
+        // The `leaf` variable is carrying raw (unhashed) data, so hash first
+        let leaf_hash = hash_gadget.hash(composer, &[*leaf])?;
+
+        // Check if leaf is one of the bottom-most siblings
+        let leaf_is_left = composer.is_eq_with_output(leaf_hash, self.path[0].0);
+
+		Ok(composer.zero_var())
+	}
+}

--- a/arkworks-plonk-circuits/src/poseidon/poseidon.rs
+++ b/arkworks-plonk-circuits/src/poseidon/poseidon.rs
@@ -27,7 +27,7 @@ struct PoseidonGadget {
 	pub params: PoseidonParametersVar,
 }
 
-trait FieldHasherGadget<F: PrimeField, P: TEModelParameters<BaseField = F>> {
+pub trait FieldHasherGadget<F: PrimeField, P: TEModelParameters<BaseField = F>> {
 	type Native: Debug + Clone;
 
 	// For easy conversion from native version

--- a/arkworks-plonk-circuits/src/poseidon/poseidon.rs
+++ b/arkworks-plonk-circuits/src/poseidon/poseidon.rs
@@ -1,7 +1,7 @@
 use ark_ec::{models::TEModelParameters, PairingEngine};
 use ark_ff::PrimeField;
 use ark_std::{fmt::Debug, vec::Vec, One};
-use arkworks_gadgets::poseidon::field_hasher::Poseidon;
+use arkworks_gadgets::poseidon::field_hasher::{FieldHasher, Poseidon};
 use plonk::{constraint_system::StandardComposer, error::Error, prelude::Variable};
 
 use crate::poseidon::sbox::{PoseidonSbox, SboxConstraints};
@@ -23,12 +23,12 @@ pub struct PoseidonParametersVar {
 }
 
 #[derive(Debug, Default)]
-struct PoseidonGadget {
+pub struct PoseidonGadget {
 	pub params: PoseidonParametersVar,
 }
 
 pub trait FieldHasherGadget<F: PrimeField, P: TEModelParameters<BaseField = F>> {
-	type Native: Debug + Clone;
+	type Native: Debug + Clone + FieldHasher<F>;
 
 	// For easy conversion from native version
 	fn from_native(composer: &mut StandardComposer<F, P>, native: Self::Native) -> Self;
@@ -252,8 +252,7 @@ mod tests {
 			.unwrap();
 
 		// VERIFIER
-		let public_inputs: Vec<PublicInputValue<Bn254Fr>> =
-			vec![PublicInputValue::<Bn254Fr>::from(expected)];
+		let public_inputs: Vec<PublicInputValue<Bn254Fr>> = vec![];
 
 		let VerifierData { key, pi_pos } = vd;
 

--- a/arkworks-plonk-circuits/src/poseidon/poseidon.rs
+++ b/arkworks-plonk-circuits/src/poseidon/poseidon.rs
@@ -1,6 +1,6 @@
 use ark_ec::{models::TEModelParameters, PairingEngine};
 use ark_ff::PrimeField;
-use ark_std::{fmt::Debug, vec::Vec, One};
+use ark_std::{fmt::Debug, vec, vec::Vec, One};
 use arkworks_gadgets::poseidon::field_hasher::{FieldHasher, Poseidon};
 use plonk::{constraint_system::StandardComposer, error::Error, prelude::Variable};
 


### PR DESCRIPTION
Adds the simplified `PathVar` for creating Merkle tree membership proofs.  The main methods are `check_membership` and `get_index`.  I stuck closely to the logic of their previous R1CS implementation but I think there's room for improvement in the `get_index` method: 

The method starts by calling `check_membership` to create a proof that the leaf is on-path.  However, at [this line](https://github.com/webb-tools/arkworks-gadgets/blob/1c88c55eeb606d97ba68082fdb8f8437bde433ac/arkworks-plonk-circuits/src/merkle_tree/mod.rs#L118) we compute the hash of the siblings at the current level of the path _and_ prove the correctness of this computation.  This is redundant because `check_membership` already did that to prove that the leaf is on-path. 

I think the best way to remove this redundancy is to remove the initial call to `check_membership` and just add a simple `composer.assert_equal(previous_hash, *root_hash);` after the for-loop.  That would prove that the path we just hashed our way through is consistent with the given Merkle root.  If you agree then I'll make those changes.

closes #75