### PR TITLE
Set membership gadget

### DIFF
--- a/arkworks-plonk-circuits/src/lib.rs
+++ b/arkworks-plonk-circuits/src/lib.rs
@@ -4,3 +4,4 @@ pub mod merkle_tree;
 pub mod mixer;
 pub mod poseidon;
 pub mod set_membership;
+pub mod utils;

--- a/arkworks-plonk-circuits/src/mixer/mod.rs
+++ b/arkworks-plonk-circuits/src/mixer/mod.rs
@@ -123,14 +123,13 @@ where
 #[cfg(test)]
 mod test {
 	use super::MixerCircuit;
-	use crate::{poseidon::poseidon::PoseidonGadget, set_membership::tests::gadget_tester};
+	use crate::{poseidon::poseidon::PoseidonGadget, utils::gadget_tester};
 	use ark_bn254::{Bn254, Fr as Bn254Fr};
-	use ark_ec::TEModelParameters;
 	use ark_ed_on_bn254::{EdwardsParameters as JubjubParameters, Fq};
-	use ark_ff::{Field, PrimeField};
+	use ark_ff::Field;
 	use ark_poly::polynomial::univariate::DensePolynomial;
 	use ark_poly_commit::{kzg10::UniversalParams, sonic_pc::SonicKZG10, PolynomialCommitment};
-	use ark_std::{log2, test_rng};
+	use ark_std::test_rng;
 	use arkworks_gadgets::{
 		ark_std::UniformRand,
 		merkle_tree::simple_merkle::SparseMerkleTree,

--- a/arkworks-plonk-circuits/src/set_membership/mod.rs
+++ b/arkworks-plonk-circuits/src/set_membership/mod.rs
@@ -1,6 +1,6 @@
 use ark_ec::models::TEModelParameters;
 use ark_ff::PrimeField;
-use ark_std::{marker::PhantomData, vec::Vec};
+use ark_std::vec::Vec;
 use plonk_core::{
 	circuit::Circuit, constraint_system::StandardComposer, error::Error, prelude::Variable,
 };
@@ -8,42 +8,9 @@ use plonk_core::{
 /// A function whose output is 1 if `member` belongs to `set`
 /// and 0 otherwise.  Contraints are added to a StandardComposer
 /// and the output is added as a variable to the StandardComposer.
-/// The set is assumed to consist of private inputs.
-fn check_private_set_membership<F, P>(
-	composer: &mut StandardComposer<F, P>,
-	set: &Vec<F>,
-	member: Variable,
-) -> Variable
-where
-	F: PrimeField,
-	P: TEModelParameters<BaseField = F>,
-{
-	let set: Vec<Variable> = set.iter().map(|x| composer.add_input(*x)).collect();
-
-	// Compute all differences between `member` and set elements
-	let mut diffs = Vec::new();
-	for x in set.iter() {
-		let diff = composer
-			.arithmetic_gate(|gate| gate.witness(member, *x, None).add(F::one(), -F::one()));
-		diffs.push(diff);
-	}
-
-	// Accumulate the product of all differences
-	let mut accumulator = composer.add_witness_to_circuit_description(F::one());
-	for diff in diffs {
-		accumulator =
-			composer.arithmetic_gate(|gate| gate.witness(accumulator, diff, None).mul(F::one()));
-	}
-
-	composer.is_zero_with_output(accumulator)
-}
-
-/// A function whose output is 1 if `member` belongs to `set`
-/// and 0 otherwise.  Contraints are added to a StandardComposer
-/// and the output is added as a variable to the StandardComposer.
-/// The set is assumed to consist of public inputs, which reduces
-/// the number of variables in the circuit.
-fn check_public_set_membership<F, P>(
+/// The set is assumed to consist of public inputs, such as roots
+/// of various Merkle trees.
+fn check_set_membership<F, P>(
 	composer: &mut StandardComposer<F, P>,
 	set: &Vec<F>,
 	member: Variable,
@@ -73,192 +40,35 @@ where
 	composer.is_zero_with_output(accumulator)
 }
 
-/// A function whose output is 1 if `member` belongs to `set`
-/// and 0 otherwise.  Contraints are added to a StandardComposer
-/// and the output is added as a variable to the StandardComposer.
-/// The set is assumed to consist of public constants, which
-/// may not be appropriate.  This cuts the number of gates in half, however.
-fn check_constant_set_membership<F, P>(
-	composer: &mut StandardComposer<F, P>,
-	set: &Vec<F>,
-	member: Variable,
-) -> Variable
-where
-	F: PrimeField,
-	P: TEModelParameters<BaseField = F>,
-{
-	// iterate through set, multiplying an accumulated value by the next
-	// difference (x - s)
-	let mut accumulated = composer.add_witness_to_circuit_description(F::one());
-	for s in set.iter() {
-		accumulated = composer.arithmetic_gate(|gate| {
-			gate.witness(member, accumulated, None)
-				.add(F::zero(), -*s)
-				.mul(F::one())
-		});
-	}
-	composer.is_zero_with_output(accumulated)
-}
-
 #[cfg(test)]
 pub(crate) mod tests {
 	//copied from ark-plonk
 	use super::*;
-	use ark_bn254::Bn254;
-	use ark_ec::{models::TEModelParameters, PairingEngine};
 	use ark_ed_on_bn254::{EdwardsParameters as JubjubParameters, Fq};
-	use ark_poly::polynomial::univariate::DensePolynomial;
-	use ark_poly_commit::{kzg10::KZG10, sonic_pc::SonicKZG10, PolynomialCommitment};
-	use ark_std::test_rng;
-	use plonk_core::proof_system::{Prover, Verifier};
 
 	#[test]
 	fn test_verify_set_membership_functions() {
 		let set = vec![Fq::from(1u32), Fq::from(2u32), Fq::from(3u32)];
 
-		// Check private version
-		{
-			let mut composer = StandardComposer::<Fq, JubjubParameters>::new();
-			let one = composer.add_input(Fq::from(1u32));
-			let member = composer.add_input(Fq::from(2u32));
+		let mut composer = StandardComposer::<Fq, JubjubParameters>::new();
+		let one = composer.add_input(Fq::from(1u32));
+		let member = composer.add_input(Fq::from(2u32));
 
-			let result_private = check_private_set_membership(&mut composer, &set, member);
-			composer.assert_equal(result_private, one);
-			composer.check_circuit_satisfied();
-		}
-
-		// Check public version
-		{
-			let mut composer = StandardComposer::<Fq, JubjubParameters>::new();
-			let one = composer.add_input(Fq::from(1u32));
-			let member = composer.add_input(Fq::from(2u32));
-
-			let result_private = check_public_set_membership(&mut composer, &set, member);
-			composer.assert_equal(result_private, one);
-			composer.check_circuit_satisfied();
-		}
-
-		// Check constant version
-		{
-			let mut composer = StandardComposer::<Fq, JubjubParameters>::new();
-			let one = composer.add_input(Fq::from(1u32));
-			let member = composer.add_input(Fq::from(2u32));
-
-			let result_private = check_constant_set_membership(&mut composer, &set, member);
-			composer.assert_equal(result_private, one);
-			composer.check_circuit_satisfied();
-		}
+		let result_private = check_set_membership(&mut composer, &set, member);
+		composer.assert_equal(result_private, one);
+		composer.check_circuit_satisfied();
 	}
 
 	#[test]
 	fn test_fail_to_verify_set_membership_functions() {
 		let set = vec![Fq::from(1u32), Fq::from(2u32), Fq::from(3u32)];
 
-		// Check private version
-		{
-			let mut composer = StandardComposer::<Fq, JubjubParameters>::new();
-			let zero = composer.zero_var();
-			let member = composer.add_input(Fq::from(4u32));
+		let mut composer = StandardComposer::<Fq, JubjubParameters>::new();
+		let zero = composer.zero_var();
+		let member = composer.add_input(Fq::from(4u32));
 
-			let result_private = check_private_set_membership(&mut composer, &set, member);
-			composer.assert_equal(result_private, zero);
-			composer.check_circuit_satisfied();
-		}
-
-		// Check public version
-		{
-			let mut composer = StandardComposer::<Fq, JubjubParameters>::new();
-			let zero = composer.zero_var();
-			let member = composer.add_input(Fq::from(4u32));
-
-			let result_private = check_public_set_membership(&mut composer, &set, member);
-			composer.assert_equal(result_private, zero);
-			composer.check_circuit_satisfied();
-		}
-
-		// Check constant version
-		{
-			let mut composer = StandardComposer::<Fq, JubjubParameters>::new();
-			let zero = composer.zero_var();
-			let member = composer.add_input(Fq::from(4u32));
-
-			let result_private = check_constant_set_membership(&mut composer, &set, member);
-			composer.assert_equal(result_private, zero);
-			composer.check_circuit_satisfied();
-		}
-	}
-
-	// This helper function is still used elsewhere in crate.  Should move it to
-	// mixer
-	pub(crate) fn gadget_tester<
-		E: PairingEngine,
-		P: TEModelParameters<BaseField = E::Fr>,
-		C: Circuit<E::Fr, P>,
-	>(
-		circuit: &mut C,
-		n: usize,
-	) -> Result<(), Error> {
-		let rng = &mut test_rng();
-		// Common View
-		let universal_params = KZG10::<E, DensePolynomial<E::Fr>>::setup(2 * n, false, rng)?;
-		// Provers View
-		let (proof, public_inputs) = {
-			// Create a prover struct
-			let mut prover: Prover<
-				E::Fr,
-				P,
-				SonicKZG10<E, DensePolynomial<<E as PairingEngine>::Fr>>,
-			> = Prover::new(b"demo");
-
-			// Additionally key the transcript
-			prover.key_transcript(b"key", b"additional seed information");
-
-			// Add gadgets
-			circuit.gadget(&mut prover.mut_cs())?;
-
-			// Commit Key
-			let (ck, _) = SonicKZG10::<E, DensePolynomial<E::Fr>>::trim(
-				&universal_params,
-				prover.circuit_size().next_power_of_two() + 6,
-				0,
-				None,
-			)
-			.unwrap();
-			// Preprocess circuit
-			prover.preprocess(&ck)?;
-
-			// Once the prove method is called, the public inputs are cleared
-			// So pre-fetch these before calling Prove
-			let public_inputs = prover.mut_cs().construct_dense_pi_vec();
-			//? let lookup_table = prover.mut_cs().lookup_table.clone();
-
-			// Compute Proof
-			(prover.prove(&ck)?, public_inputs)
-		};
-		// Verifiers view
-		//
-		// Create a Verifier object
-		let mut verifier = Verifier::new(b"demo");
-
-		// Additionally key the transcript
-		verifier.key_transcript(b"key", b"additional seed information");
-
-		// Add gadgets
-		circuit.gadget(&mut verifier.mut_cs())?;
-
-		// Compute Commit and Verifier Key
-		let (sonic_ck, sonic_vk) = SonicKZG10::<E, DensePolynomial<E::Fr>>::trim(
-			&universal_params,
-			verifier.circuit_size().next_power_of_two(),
-			0,
-			None,
-		)
-		.unwrap();
-
-		// Preprocess circuit
-		verifier.preprocess(&sonic_ck)?;
-
-		// Verify proof
-		Ok(verifier.verify(&proof, &sonic_vk, &public_inputs)?)
+		let result_private = check_set_membership(&mut composer, &set, member);
+		composer.assert_equal(result_private, zero);
+		composer.check_circuit_satisfied();
 	}
 }

--- a/arkworks-plonk-circuits/src/set_membership/mod.rs
+++ b/arkworks-plonk-circuits/src/set_membership/mod.rs
@@ -1,5 +1,3 @@
-use std::ops::{Add, Mul};
-
 use ark_ec::models::TEModelParameters;
 use ark_ff::PrimeField;
 use ark_std::{marker::PhantomData, vec::Vec};

--- a/arkworks-plonk-circuits/src/utils.rs
+++ b/arkworks-plonk-circuits/src/utils.rs
@@ -1,0 +1,78 @@
+use ark_ec::{models::TEModelParameters, PairingEngine};
+use ark_poly::polynomial::univariate::DensePolynomial;
+use ark_poly_commit::{kzg10::KZG10, sonic_pc::SonicKZG10, PolynomialCommitment};
+use ark_std::test_rng;
+use plonk_core::{
+	prelude::*,
+	proof_system::{Prover, Verifier},
+};
+
+// A helper function to prove/verify plonk circuits
+pub(crate) fn gadget_tester<
+	E: PairingEngine,
+	P: TEModelParameters<BaseField = E::Fr>,
+	C: Circuit<E::Fr, P>,
+>(
+	circuit: &mut C,
+	n: usize,
+) -> Result<(), Error> {
+	let rng = &mut test_rng();
+	// Common View
+	let universal_params = KZG10::<E, DensePolynomial<E::Fr>>::setup(2 * n, false, rng)?;
+	// Provers View
+	let (proof, public_inputs) = {
+		// Create a prover struct
+		let mut prover: Prover<E::Fr, P, SonicKZG10<E, DensePolynomial<<E as PairingEngine>::Fr>>> =
+			Prover::new(b"demo");
+
+		// Additionally key the transcript
+		prover.key_transcript(b"key", b"additional seed information");
+
+		// Add gadgets
+		circuit.gadget(&mut prover.mut_cs())?;
+
+		// Commit Key
+		let (ck, _) = SonicKZG10::<E, DensePolynomial<E::Fr>>::trim(
+			&universal_params,
+			prover.circuit_size().next_power_of_two() + 6,
+			0,
+			None,
+		)
+		.unwrap();
+		// Preprocess circuit
+		prover.preprocess(&ck)?;
+
+		// Once the prove method is called, the public inputs are cleared
+		// So pre-fetch these before calling Prove
+		let public_inputs = prover.mut_cs().construct_dense_pi_vec();
+		//? let lookup_table = prover.mut_cs().lookup_table.clone();
+
+		// Compute Proof
+		(prover.prove(&ck)?, public_inputs)
+	};
+	// Verifiers view
+	//
+	// Create a Verifier object
+	let mut verifier = Verifier::new(b"demo");
+
+	// Additionally key the transcript
+	verifier.key_transcript(b"key", b"additional seed information");
+
+	// Add gadgets
+	circuit.gadget(&mut verifier.mut_cs())?;
+
+	// Compute Commit and Verifier Key
+	let (sonic_ck, sonic_vk) = SonicKZG10::<E, DensePolynomial<E::Fr>>::trim(
+		&universal_params,
+		verifier.circuit_size().next_power_of_two(),
+		0,
+		None,
+	)
+	.unwrap();
+
+	// Preprocess circuit
+	verifier.preprocess(&sonic_ck)?;
+
+	// Verify proof
+	Ok(verifier.verify(&proof, &sonic_vk, &public_inputs)?)
+}


### PR DESCRIPTION
Adds functions for checking set membership.  These all have the form

```rust
check_set_membership(composer: &mut StandardComposer<F, P>, set: &Vec<F>, member: F) -> Variable
```

So they accept as arguments a standard composer, a set, and a potential member of that set.  The output is a variable carrying 1 if `member` belongs to `set` and 0 otherwise.

I wrote 3 versions of the function that differ in the way they treat `set`:

*   `check_private_set_membership` treats the set as consisting of private inputs.  This version probably doesn't make much sense because what's the value of proving that a secret witness belongs to a secret set? I don't know, but I included it just in case there is such a use case.  Let me know your thoughts.
*   `check_public_set_membership` treats the set as consisting of public inputs.  This seems to be the correct version for a set that consists of something like Merkle roots of various trees, since these roots would all be public knowledge.  Treating the set's elements as public inputs reduces the number of variables that need to be added to the composer.
*   `check_constant_set_membership` treats the set as consisting of constants.  The advantage of this is that I noticed a way to cut the number of gates in half by treating the set's elements as constants (see below).  The problem is that this probably isn't appropriate for sets that change over time, like roots of Merkle trees.  But maybe it has a use case.

If the elements of `set` can be treated as constants then this optimization works:

Ultimately we are checking that the following product equals 0:

```
(x - s_1)(x - s_2) ... (x - s_n)
```

 If we let `pi_k` denote the first _k_ terms in that product then `pi_{k+1} = pi_k (x - s_{k+1})` , so it's enough to add a constraint `pi_{k+1} = pi_k * x - s_{k+1} * pi_k`.  As long as `s_{k+1}` is a constant, this constraint can be added in a single arithmetic gate, as opposed to the 2 arithmetic gates needed to perform the subtraction and multiplication in separate operations.  At the end we check that the final variable `pi_n` equals 0.

Unfortunately this doesn't work if we want to treat the set as public input because plonk doesn't allow us to multiply variables by public input values, only to add.

This will close #120