### PR TITLE
Create plonk anchor module

### DIFF
--- a/arkworks-plonk-circuits/src/anchor/mod.rs
+++ b/arkworks-plonk-circuits/src/anchor/mod.rs
@@ -1,0 +1,824 @@
+use crate::{merkle_tree::PathGadget, poseidon::poseidon::FieldHasherGadget, set_membership::check_set_membership, mixer::add_public_input_variable};
+use ark_ec::{models::TEModelParameters, PairingEngine};
+use ark_std::{One, Zero};
+use arkworks_gadgets::merkle_tree::simple_merkle::Path;
+use plonk_core::{
+	circuit::Circuit, constraint_system::StandardComposer, error::Error, prelude::Variable,
+};
+
+pub struct AnchorCircuit<
+	E: PairingEngine,
+	P: TEModelParameters<BaseField = E::Fr>,
+	HG: FieldHasherGadget<E, P>,
+	const N: usize,
+    const M: usize,
+> {
+    chain_id: E::Fr,
+	secret: E::Fr,
+	nullifier: E::Fr,
+	nullifier_hash: E::Fr,
+	path: Path<E::Fr, HG::Native, N>,
+	roots: [E::Fr; M],
+	arbitrary_data: E::Fr,
+	hasher: HG::Native,
+}
+
+impl<E, P, HG, const N: usize, const M: usize> AnchorCircuit<E, P, HG, N, M>
+where
+	E: PairingEngine,
+	P: TEModelParameters<BaseField = E::Fr>,
+	HG: FieldHasherGadget<E, P>,
+{
+	pub fn new(
+        chain_id: E::Fr,
+		secret: E::Fr,
+		nullifier: E::Fr,
+		nullifier_hash: E::Fr,
+		path: Path<E::Fr, HG::Native, N>,
+		roots: [E::Fr; M],
+		arbitrary_data: E::Fr,
+		hasher: HG::Native,
+	) -> Self {
+		Self {
+			chain_id,
+            secret,
+			nullifier,
+			nullifier_hash,
+			path,
+			roots,
+			arbitrary_data,
+			hasher,
+		}
+	}
+}
+
+impl<E, P, HG, const N: usize, const M: usize> Circuit<E, P> for AnchorCircuit<E, P, HG, N, M>
+where
+	E: PairingEngine,
+	P: TEModelParameters<BaseField = E::Fr>,
+	HG: FieldHasherGadget<E, P>,
+{
+	const CIRCUIT_ID: [u8; 32] = [0xff; 32];
+
+	fn gadget(&mut self, composer: &mut StandardComposer<E, P>) -> Result<(), Error> {
+		// Private Inputs
+		let secret = composer.add_input(self.secret);
+		let nullifier = composer.add_input(self.nullifier);
+		let path_gadget = PathGadget::<E, P, HG, N>::from_native(composer, self.path.clone());
+
+		// Public Inputs
+        let chain_id = add_public_input_variable(composer, self.chain_id);
+		let nullifier_hash = add_public_input_variable(composer, self.nullifier_hash);
+		let roots = self.roots
+            .iter()
+            .map(|root| add_public_input_variable(composer, *root))
+            .collect::<Vec<Variable>>();
+		let arbitrary_data = add_public_input_variable(composer, self.arbitrary_data);
+
+		// Create the hasher_gadget from native
+		let hasher_gadget: HG =
+			FieldHasherGadget::<E, P>::from_native(composer, self.hasher.clone());
+
+		// Preimage proof of nullifier
+		let res_nullifier = hasher_gadget.hash_two(composer, &nullifier, &nullifier)?;
+		// TODO: (This has 1 more gate than skipping the nullifier_hash variable and
+		// putting this straight in to a poly_gate)
+		composer.assert_equal(res_nullifier, nullifier_hash);
+
+		// Preimage proof of leaf hash
+		let res_leaf = hasher_gadget.hash_two(composer, &secret, &nullifier)?;
+
+		// Proof of Merkle tree set membership
+        let calculated_root = path_gadget.calculate_root(composer, &res_leaf, &hasher_gadget)?;
+        let result = check_set_membership(composer, &self.roots.to_vec(), calculated_root);
+		let one = composer.add_witness_to_circuit_description(E::Fr::one());
+		composer.assert_equal(result, one);
+
+		// Safety constraint to prevent tampering with arbitrary_data
+		let _arbitrary_data_squared = composer.arithmetic_gate(|gate| {
+			gate.witness(arbitrary_data, arbitrary_data, None)
+				.mul(E::Fr::one())
+		});
+		Ok(())
+	}
+
+	fn padded_circuit_size(&self) -> usize {
+		1 << 21
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::AnchorCircuit;
+	use crate::{poseidon::poseidon::PoseidonGadget, utils::gadget_tester};
+	use ark_bn254::{Bn254, Fr as Bn254Fr};
+	use ark_ed_on_bn254::{EdwardsParameters as JubjubParameters, Fq};
+	use ark_ff::Field;
+	use ark_poly::polynomial::univariate::DensePolynomial;
+	use ark_poly_commit::{kzg10::{UniversalParams, self}, sonic_pc::{SonicKZG10, self}, PolynomialCommitment};
+	use ark_serialize::{CanonicalSerialize, CanonicalDeserialize};
+use ark_std::test_rng;
+	use arkworks_gadgets::{
+		ark_std::UniformRand,
+		merkle_tree::simple_merkle::SparseMerkleTree,
+		poseidon::field_hasher::{FieldHasher, Poseidon},
+	};
+	use arkworks_utils::utils::common::{setup_params_x5_3, Curve};
+	use plonk_core::{
+		prelude::*,
+		proof_system::{Prover, Verifier},
+	};
+
+	type PoseidonBn254 = Poseidon<Fq>;
+
+    const BRIDGE_SIZE: usize = 2;
+
+	#[test]
+	fn should_verify_correct_mixer_plonk() {
+		let rng = &mut test_rng();
+		let curve = Curve::Bn254;
+
+		let params = setup_params_x5_3(curve);
+		let poseidon_native = PoseidonBn254 { params };
+
+		// Randomly generated secrets
+		let secret = Fq::rand(rng);
+		let nullifier = Fq::rand(rng);
+
+		// Public data
+        let chain_id = Fq::from(1u32);
+		let arbitrary_data = Fq::rand(rng);
+		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
+		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
+
+		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
+		// scalars, then add leaf_hash as the final leaf
+		const HEIGHT: usize = 6usize;
+		let last_index = 1 << (HEIGHT - 1) - 1;
+		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
+		for i in 0..last_index {
+			leaves[i] = Fq::rand(rng);
+		}
+		leaves[last_index] = leaf_hash;
+		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
+			&leaves,
+			&poseidon_native,
+			&[0u8; 32],
+		)
+		.unwrap();
+
+        let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+		roots[0] = tree.root();
+
+		// Path
+		let path = tree.generate_membership_proof(last_index as u64);
+
+		// Create AnchorCircuit
+		let mut anchor = AnchorCircuit::<Bn254, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
+            chain_id,
+			secret,
+			nullifier,
+			nullifier_hash,
+			path,
+			roots,
+			arbitrary_data,
+			poseidon_native,
+		);
+
+		let res = gadget_tester::<Bn254, JubjubParameters, _>(&mut anchor, 1 << 17);
+		assert!(res.is_ok(), "{:?}", res.err().unwrap());
+	}
+
+	#[test]
+	fn should_fail_with_invalid_root_plonk() {
+		let rng = &mut test_rng();
+		let curve = Curve::Bn254;
+
+		let params = setup_params_x5_3(curve);
+		let poseidon_native = PoseidonBn254 { params };
+
+		// Randomly generated secrets
+		let secret = Fq::rand(rng);
+		let nullifier = Fq::rand(rng);
+
+		// Public data
+        let chain_id = Fq::from(1u32);
+		let arbitrary_data = Fq::rand(rng);
+		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
+		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
+
+		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
+		// scalars, then add leaf_hash as the final leaf
+		const HEIGHT: usize = 6usize;
+		let last_index = 1 << (HEIGHT - 1) - 1;
+		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
+		for i in 0..last_index {
+			leaves[i] = Fq::rand(rng);
+		}
+		leaves[last_index] = leaf_hash;
+		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
+			&leaves,
+			&poseidon_native,
+			&[0u8; 32],
+		)
+		.unwrap();
+        let mut root = tree.root();
+		let bad_root = root.double();
+        let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+		roots[0] = bad_root;
+
+		// Path
+		let path = tree.generate_membership_proof(last_index as u64);
+
+		// Create AnchorCircuit
+		let mut anchor = AnchorCircuit::<Bn254, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
+            chain_id,
+			secret,
+			nullifier,
+			nullifier_hash,
+			path,
+			roots,
+			arbitrary_data,
+			poseidon_native,
+		);
+
+		// Fill a composer to extract the public_inputs
+		let mut composer = StandardComposer::<Bn254, JubjubParameters>::new();
+		let _ = anchor.gadget(&mut composer);
+		let public_inputs = composer.construct_dense_pi_vec();
+
+		// Go through proof generation/verification
+		let u_params: UniversalParams<Bn254> =
+			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
+		let proof = {
+			// Create a prover struct
+			let mut prover =
+				Prover::<Bn254, JubjubParameters>::new(
+					b"mixer",
+				);
+			prover.key_transcript(b"key", b"additional seed information");
+			// Add gadgets
+			let _ = anchor.gadget(prover.mut_cs());
+			// Commit Key (being lazy with error)
+			let (ck, _) =
+				SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
+					.unwrap();
+			// Preprocess circuit
+			let _ = prover.preprocess(&ck.powers());
+			// Compute Proof
+			prover.prove(&ck.powers()).unwrap()
+		};
+
+		// Verifier's view
+
+		// Create a Verifier object
+		let mut verifier = Verifier::new(b"mixer");
+		verifier.key_transcript(b"key", b"additional seed information");
+		// Add gadgets
+		let _ = anchor.gadget(verifier.mut_cs());
+		// Compute Commit and Verifier key
+		let (ck, vk) =
+			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
+				.unwrap();
+		// Preprocess circuit
+		verifier.preprocess(&ck.powers()).unwrap();
+
+		// Verify proof
+        let mut vk_bytes = Vec::new();
+        sonic_pc::VerifierKey::<Bn254>::serialize(&vk, &mut vk_bytes).unwrap();
+        let kzg_vk = kzg10::VerifierKey::<Bn254>::deserialize(&vk_bytes[..]).unwrap();
+		let res = verifier.verify(&proof, &kzg_vk, &public_inputs).unwrap_err();
+		match res {
+			Error::ProofVerificationError => (),
+			err => panic!("Unexpected error: {:?}", err),
+		};
+	}
+
+	#[test]
+	fn should_fail_with_wrong_secret_plonk() {
+		let rng = &mut test_rng();
+		let curve = Curve::Bn254;
+
+		let params = setup_params_x5_3(curve);
+		let poseidon_native = PoseidonBn254 { params };
+
+		// Randomly generated secrets
+		let secret = Fq::rand(rng);
+		let nullifier = Fq::rand(rng);
+
+		// Public data
+        let chain_id = Fq::from(1u32);
+		let arbitrary_data = Fq::rand(rng);
+		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
+		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
+
+		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
+		// scalars, then add leaf_hash as the final leaf
+		const HEIGHT: usize = 6usize;
+		let last_index = 1 << (HEIGHT - 1) - 1;
+		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
+		for i in 0..last_index {
+			leaves[i] = Fq::rand(rng);
+		}
+		leaves[last_index] = leaf_hash;
+		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
+			&leaves,
+			&poseidon_native,
+			&[0u8; 32],
+		)
+		.unwrap();
+        let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+        roots[0] = tree.root();
+		// Path
+		let path = tree.generate_membership_proof(last_index as u64);
+
+		// An incorrect secret value to use below
+		let bad_secret = secret.double();
+
+		// Create AnchorCircuit
+		let mut anchor = AnchorCircuit::<Bn254, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
+            chain_id,
+			bad_secret,
+			nullifier,
+			nullifier_hash,
+			path,
+			roots,
+			arbitrary_data,
+			poseidon_native,
+		);
+
+		// Fill a composer to extract the public_inputs
+		let mut composer = StandardComposer::<Bn254, JubjubParameters>::new();
+		let _ = anchor.gadget(&mut composer);
+		let public_inputs = composer.construct_dense_pi_vec();
+
+		// Go through proof generation/verification
+		let u_params: UniversalParams<Bn254> =
+			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
+		let proof = {
+			// Create a prover struct
+			let mut prover =
+				Prover::<Bn254, JubjubParameters>::new(
+					b"mixer",
+				);
+			prover.key_transcript(b"key", b"additional seed information");
+			// Add gadgets
+			let _ = anchor.gadget(prover.mut_cs());
+			// Commit Key (being lazy with error)
+			let (ck, _) =
+				SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
+					.unwrap();
+			// Preprocess circuit
+			let _ = prover.preprocess(&ck.powers());
+			// Compute Proof
+			prover.prove(&ck.powers()).unwrap()
+		};
+
+		// Verifier's view
+
+		// Create a Verifier object
+		let mut verifier = Verifier::new(b"mixer");
+		verifier.key_transcript(b"key", b"additional seed information");
+		// Add gadgets
+		let _ = anchor.gadget(verifier.mut_cs());
+		// Compute Commit and Verifier key
+		let (ck, vk) =
+			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
+				.unwrap();
+		// Preprocess circuit
+		verifier.preprocess(&ck.powers()).unwrap();
+
+		// Verify proof
+        let mut vk_bytes = Vec::new();
+        sonic_pc::VerifierKey::<Bn254>::serialize(&vk, &mut vk_bytes).unwrap();
+        let kzg_vk = kzg10::VerifierKey::<Bn254>::deserialize(&vk_bytes[..]).unwrap();
+		let res = verifier.verify(&proof, &kzg_vk, &public_inputs).unwrap_err();
+		match res {
+			Error::ProofVerificationError => (),
+			err => panic!("Unexpected error: {:?}", err),
+		};
+	}
+
+	#[test]
+	fn should_fail_with_wrong_nullifier_plonk() {
+		let rng = &mut test_rng();
+		let curve = Curve::Bn254;
+
+		let params = setup_params_x5_3(curve);
+		let poseidon_native = PoseidonBn254 { params };
+
+		// Randomly generated secrets
+		let secret = Fq::rand(rng);
+		let nullifier = Fq::rand(rng);
+
+		// Public data
+        let chain_id = Fq::from(1u32);
+		let arbitrary_data = Fq::rand(rng);
+		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
+		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
+
+		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
+		// scalars, then add leaf_hash as the final leaf
+		const HEIGHT: usize = 6usize;
+		let last_index = 1 << (HEIGHT - 1) - 1;
+		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
+		for i in 0..last_index {
+			leaves[i] = Fq::rand(rng);
+		}
+		leaves[last_index] = leaf_hash;
+		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
+			&leaves,
+			&poseidon_native,
+			&[0u8; 32],
+		)
+		.unwrap();
+        let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+        roots[0] = tree.root();
+
+		// Path
+		let path = tree.generate_membership_proof(last_index as u64);
+
+		// An incorrect secret value to use below
+		let bad_nullifier = nullifier.double();
+
+		// Create AnchorCircuit
+		let mut anchor = AnchorCircuit::<Bn254, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
+            chain_id,
+			secret,
+			bad_nullifier,
+			nullifier_hash,
+			path,
+			roots,
+			arbitrary_data,
+			poseidon_native,
+		);
+
+		// Fill a composer to extract the public_inputs
+		let mut composer = StandardComposer::<Bn254, JubjubParameters>::new();
+		let _ = anchor.gadget(&mut composer);
+		let public_inputs = composer.construct_dense_pi_vec();
+
+		// Go through proof generation/verification
+		let u_params: UniversalParams<Bn254> =
+			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
+		let proof = {
+			// Create a prover struct
+			let mut prover =
+				Prover::<Bn254, JubjubParameters>::new(
+					b"mixer",
+				);
+			prover.key_transcript(b"key", b"additional seed information");
+			// Add gadgets
+			let _ = anchor.gadget(prover.mut_cs());
+			// Commit Key (being lazy with error)
+			let (ck, _) =
+				SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
+					.unwrap();
+			// Preprocess circuit
+			let _ = prover.preprocess(&ck.powers());
+			// Compute Proof
+			prover.prove(&ck.powers()).unwrap()
+		};
+
+		// Verifier's view
+
+		// Create a Verifier object
+		let mut verifier = Verifier::new(b"mixer");
+		verifier.key_transcript(b"key", b"additional seed information");
+		// Add gadgets
+		let _ = anchor.gadget(verifier.mut_cs());
+		// Compute Commit and Verifier key
+		let (ck, vk) =
+			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
+				.unwrap();
+		// Preprocess circuit
+		verifier.preprocess(&ck.powers()).unwrap();
+
+		// Verify proof
+        let mut vk_bytes = Vec::new();
+        sonic_pc::VerifierKey::<Bn254>::serialize(&vk, &mut vk_bytes).unwrap();
+        let kzg_vk = kzg10::VerifierKey::<Bn254>::deserialize(&vk_bytes[..]).unwrap();
+		let res = verifier.verify(&proof, &kzg_vk, &public_inputs).unwrap_err();
+		match res {
+			Error::ProofVerificationError => (),
+			err => panic!("Unexpected error: {:?}", err),
+		};
+	}
+
+	#[test]
+	fn should_fail_with_wrong_path_plonk() {
+		let rng = &mut test_rng();
+		let curve = Curve::Bn254;
+
+		let params = setup_params_x5_3(curve);
+		let poseidon_native = PoseidonBn254 { params };
+
+		// Randomly generated secrets
+		let secret = Fq::rand(rng);
+		let nullifier = Fq::rand(rng);
+
+		// Public data
+        let chain_id = Fq::from(1u32);
+		let arbitrary_data = Fq::rand(rng);
+		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
+		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
+
+		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
+		// scalars, then add leaf_hash as the final leaf
+		const HEIGHT: usize = 6usize;
+		let last_index = 1 << (HEIGHT - 1) - 1;
+		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
+		for i in 0..last_index {
+			leaves[i] = Fq::rand(rng);
+		}
+		leaves[last_index] = leaf_hash;
+		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
+			&leaves,
+			&poseidon_native,
+			&[0u8; 32],
+		)
+		.unwrap();
+        let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+        roots[0] = tree.root();
+
+		// An incorrect path to use below
+		let bad_path = tree.generate_membership_proof((last_index as u64) - 1);
+
+		// Create AnchorCircuit
+		let mut anchor = AnchorCircuit::<Bn254, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
+            chain_id,
+			secret,
+			nullifier,
+			nullifier_hash,
+			bad_path,
+			roots,
+			arbitrary_data,
+			poseidon_native,
+		);
+
+		// Fill a composer to extract the public_inputs
+		let mut composer = StandardComposer::<Bn254, JubjubParameters>::new();
+		let _ = anchor.gadget(&mut composer);
+		let public_inputs = composer.construct_dense_pi_vec();
+
+		// Go through proof generation/verification
+		let u_params: UniversalParams<Bn254> =
+			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
+		let proof = {
+			// Create a prover struct
+			let mut prover =
+				Prover::<Bn254, JubjubParameters>::new(
+					b"mixer",
+				);
+			prover.key_transcript(b"key", b"additional seed information");
+			// Add gadgets
+			let _ = anchor.gadget(prover.mut_cs());
+			// Commit Key (being lazy with error)
+			let (ck, _) =
+				SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
+					.unwrap();
+			// Preprocess circuit
+			let _ = prover.preprocess(&ck.powers());
+			// Compute Proof
+			prover.prove(&ck.powers()).unwrap()
+		};
+
+		// Verifier's view
+
+		// Create a Verifier object
+		let mut verifier = Verifier::new(b"mixer");
+		verifier.key_transcript(b"key", b"additional seed information");
+		// Add gadgets
+		let _ = anchor.gadget(verifier.mut_cs());
+		// Compute Commit and Verifier key
+		let (ck, vk) =
+			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
+				.unwrap();
+		// Preprocess circuit
+		verifier.preprocess(&ck.powers()).unwrap();
+
+		// Verify proof
+        let mut vk_bytes = Vec::new();
+        sonic_pc::VerifierKey::<Bn254>::serialize(&vk, &mut vk_bytes).unwrap();
+        let kzg_vk = kzg10::VerifierKey::<Bn254>::deserialize(&vk_bytes[..]).unwrap();
+		let res = verifier.verify(&proof, &kzg_vk, &public_inputs).unwrap_err();
+		match res {
+			Error::ProofVerificationError => (),
+			err => panic!("Unexpected error: {:?}", err),
+		};
+	}
+
+	#[test]
+	fn should_fail_with_wrong_nullifier_hash_plonk() {
+		let rng = &mut test_rng();
+		let curve = Curve::Bn254;
+
+		let params = setup_params_x5_3(curve);
+		let poseidon_native = PoseidonBn254 { params };
+
+		// Randomly generated secrets
+		let secret = Fq::rand(rng);
+		let nullifier = Fq::rand(rng);
+
+		// Public data
+        let chain_id = Fq::from(1u32);
+		let arbitrary_data = Fq::rand(rng);
+		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
+		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
+
+		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
+		// scalars, then add leaf_hash as the final leaf
+		const HEIGHT: usize = 6usize;
+		let last_index = 1 << (HEIGHT - 1) - 1;
+		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
+		for i in 0..last_index {
+			leaves[i] = Fq::rand(rng);
+		}
+		leaves[last_index] = leaf_hash;
+		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
+			&leaves,
+			&poseidon_native,
+			&[0u8; 32],
+		)
+		.unwrap();
+        let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+        roots[0] = tree.root();
+
+		// Path
+		let path = tree.generate_membership_proof(last_index as u64);
+
+		// Incorrect nullifier hash to use below
+		let bad_nullifier_hash = nullifier_hash.double();
+
+		// Create AnchorCircuit
+		let mut anchor = AnchorCircuit::<Bn254, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
+            chain_id,
+			secret,
+			nullifier,
+			bad_nullifier_hash,
+			path,
+			roots,
+			arbitrary_data,
+			poseidon_native,
+		);
+
+		// Fill a composer to extract the public_inputs
+		let mut composer = StandardComposer::<Bn254, JubjubParameters>::new();
+		let _ = anchor.gadget(&mut composer);
+		let public_inputs = composer.construct_dense_pi_vec();
+
+		// Go through proof generation/verification
+		let u_params: UniversalParams<Bn254> =
+			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
+		let proof = {
+			// Create a prover struct
+			let mut prover =
+				Prover::<Bn254, JubjubParameters>::new(
+					b"mixer",
+				);
+			prover.key_transcript(b"key", b"additional seed information");
+			// Add gadgets
+			let _ = anchor.gadget(prover.mut_cs());
+			// Commit Key (being lazy with error)
+			let (ck, _) =
+				SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
+					.unwrap();
+			// Preprocess circuit
+			let _ = prover.preprocess(&ck.powers());
+			// Compute Proof
+			prover.prove(&ck.powers()).unwrap()
+		};
+
+		// Verifier's view
+
+		// Create a Verifier object
+		let mut verifier = Verifier::new(b"mixer");
+		verifier.key_transcript(b"key", b"additional seed information");
+		// Add gadgets
+		let _ = anchor.gadget(verifier.mut_cs());
+		// Compute Commit and Verifier key
+		let (ck, vk) =
+			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
+				.unwrap();
+		// Preprocess circuit
+		verifier.preprocess(&ck.powers()).unwrap();
+
+		// Verify proof
+        let mut vk_bytes = Vec::new();
+        sonic_pc::VerifierKey::<Bn254>::serialize(&vk, &mut vk_bytes).unwrap();
+        let kzg_vk = kzg10::VerifierKey::<Bn254>::deserialize(&vk_bytes[..]).unwrap();
+		let res = verifier.verify(&proof, &kzg_vk, &public_inputs).unwrap_err();
+		match res {
+			Error::ProofVerificationError => (),
+			err => panic!("Unexpected error: {:?}", err),
+		};
+	}
+
+	#[test]
+	fn should_fail_with_wrong_arbitrary_data_plonk() {
+		let rng = &mut test_rng();
+		let curve = Curve::Bn254;
+
+		let params = setup_params_x5_3(curve);
+		let poseidon_native = PoseidonBn254 { params };
+
+		// Randomly generated secrets
+		let secret = Fq::rand(rng);
+		let nullifier = Fq::rand(rng);
+
+		// Public data
+        let chain_id = Fq::from(1u32);
+		let arbitrary_data = Fq::rand(rng);
+		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
+		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
+
+		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
+		// scalars, then add leaf_hash as the final leaf
+		const HEIGHT: usize = 6usize;
+		let last_index = 1 << (HEIGHT - 1) - 1;
+		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
+		for i in 0..last_index {
+			leaves[i] = Fq::rand(rng);
+		}
+		leaves[last_index] = leaf_hash;
+		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
+			&leaves,
+			&poseidon_native,
+			&[0u8; 32],
+		)
+		.unwrap();
+        let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+        roots[0] = tree.root();
+
+		// Path
+		let path = tree.generate_membership_proof(last_index as u64);
+
+		// Create AnchorCircuit
+		let mut anchor = AnchorCircuit::<Bn254, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
+            chain_id,
+			secret,
+			nullifier,
+			nullifier_hash,
+			path,
+			roots,
+			arbitrary_data,
+			poseidon_native,
+		);
+
+		// Fill a composer to extract the public_inputs
+		let mut composer = StandardComposer::<Bn254, JubjubParameters>::new();
+		let _ = anchor.gadget(&mut composer);
+		let mut public_inputs = composer.construct_dense_pi_vec();
+
+		// Go through proof generation/verification
+		let u_params: UniversalParams<Bn254> =
+			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
+		let proof = {
+			// Create a prover struct
+			let mut prover =
+				Prover::<Bn254, JubjubParameters>::new(
+					b"mixer",
+				);
+			prover.key_transcript(b"key", b"additional seed information");
+			// Add gadgets
+			let _ = anchor.gadget(prover.mut_cs());
+			// Commit Key (being lazy with error)
+			let (ck, _) =
+				SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
+					.unwrap();
+			// Preprocess circuit
+			let _ = prover.preprocess(&ck.powers());
+			// Compute Proof
+			prover.prove(&ck.powers()).unwrap()
+		};
+
+		// Verifier's view
+
+		// Create a Verifier object
+		let mut verifier = Verifier::new(b"mixer");
+		verifier.key_transcript(b"key", b"additional seed information");
+		// Add gadgets
+		let _ = anchor.gadget(verifier.mut_cs());
+		// Compute Commit and Verifier key
+		let (ck, vk) =
+			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
+				.unwrap();
+		// Preprocess circuit
+		verifier.preprocess(&ck.powers()).unwrap();
+
+		// The arbitrary data is stored at index 5 of the public input vector:
+		assert_eq!(arbitrary_data, public_inputs[5]);
+		// Modify the arbitrary data so that prover/verifier disagree
+		public_inputs[5].double_in_place();
+
+		// Verify proof
+        let mut vk_bytes = Vec::new();
+        sonic_pc::VerifierKey::<Bn254>::serialize(&vk, &mut vk_bytes).unwrap();
+        let kzg_vk = kzg10::VerifierKey::<Bn254>::deserialize(&vk_bytes[..]).unwrap();
+		let res = verifier.verify(&proof, &kzg_vk, &public_inputs).unwrap_err();
+		match res {
+			Error::ProofVerificationError => (),
+			err => panic!("Unexpected error: {:?}", err),
+		};
+	}
+}

--- a/arkworks-plonk-circuits/src/anchor/mod.rs
+++ b/arkworks-plonk-circuits/src/anchor/mod.rs
@@ -1,4 +1,7 @@
-use crate::{merkle_tree::PathGadget, poseidon::poseidon::FieldHasherGadget, set_membership::check_set_membership, mixer::add_public_input_variable};
+use crate::{
+	merkle_tree::PathGadget, mixer::add_public_input_variable,
+	poseidon::poseidon::FieldHasherGadget, set_membership::check_set_membership,
+};
 use ark_ec::{models::TEModelParameters, PairingEngine};
 use ark_std::{One, Zero};
 use arkworks_gadgets::merkle_tree::simple_merkle::Path;
@@ -11,9 +14,9 @@ pub struct AnchorCircuit<
 	P: TEModelParameters<BaseField = E::Fr>,
 	HG: FieldHasherGadget<E, P>,
 	const N: usize,
-    const M: usize,
+	const M: usize,
 > {
-    chain_id: E::Fr,
+	chain_id: E::Fr,
 	secret: E::Fr,
 	nullifier: E::Fr,
 	nullifier_hash: E::Fr,
@@ -30,7 +33,7 @@ where
 	HG: FieldHasherGadget<E, P>,
 {
 	pub fn new(
-        chain_id: E::Fr,
+		chain_id: E::Fr,
 		secret: E::Fr,
 		nullifier: E::Fr,
 		nullifier_hash: E::Fr,
@@ -41,7 +44,7 @@ where
 	) -> Self {
 		Self {
 			chain_id,
-            secret,
+			secret,
 			nullifier,
 			nullifier_hash,
 			path,
@@ -67,12 +70,13 @@ where
 		let path_gadget = PathGadget::<E, P, HG, N>::from_native(composer, self.path.clone());
 
 		// Public Inputs
-        let chain_id = add_public_input_variable(composer, self.chain_id);
+		let chain_id = add_public_input_variable(composer, self.chain_id);
 		let nullifier_hash = add_public_input_variable(composer, self.nullifier_hash);
-		let roots = self.roots
-            .iter()
-            .map(|root| add_public_input_variable(composer, *root))
-            .collect::<Vec<Variable>>();
+		let roots = self
+			.roots
+			.iter()
+			.map(|root| add_public_input_variable(composer, *root))
+			.collect::<Vec<Variable>>();
 		let arbitrary_data = add_public_input_variable(composer, self.arbitrary_data);
 
 		// Create the hasher_gadget from native
@@ -89,8 +93,8 @@ where
 		let res_leaf = hasher_gadget.hash_two(composer, &secret, &nullifier)?;
 
 		// Proof of Merkle tree set membership
-        let calculated_root = path_gadget.calculate_root(composer, &res_leaf, &hasher_gadget)?;
-        let result = check_set_membership(composer, &self.roots.to_vec(), calculated_root);
+		let calculated_root = path_gadget.calculate_root(composer, &res_leaf, &hasher_gadget)?;
+		let result = check_set_membership(composer, &self.roots.to_vec(), calculated_root);
 		let one = composer.add_witness_to_circuit_description(E::Fr::one());
 		composer.assert_equal(result, one);
 
@@ -115,9 +119,13 @@ mod test {
 	use ark_ed_on_bn254::{EdwardsParameters as JubjubParameters, Fq};
 	use ark_ff::Field;
 	use ark_poly::polynomial::univariate::DensePolynomial;
-	use ark_poly_commit::{kzg10::{UniversalParams, self}, sonic_pc::{SonicKZG10, self}, PolynomialCommitment};
-	use ark_serialize::{CanonicalSerialize, CanonicalDeserialize};
-use ark_std::test_rng;
+	use ark_poly_commit::{
+		kzg10::{self, UniversalParams},
+		sonic_pc::{self, SonicKZG10},
+		PolynomialCommitment,
+	};
+	use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+	use ark_std::test_rng;
 	use arkworks_gadgets::{
 		ark_std::UniformRand,
 		merkle_tree::simple_merkle::SparseMerkleTree,
@@ -131,7 +139,7 @@ use ark_std::test_rng;
 
 	type PoseidonBn254 = Poseidon<Fq>;
 
-    const BRIDGE_SIZE: usize = 2;
+	const BRIDGE_SIZE: usize = 2;
 
 	#[test]
 	fn should_verify_correct_anchor_plonk() {
@@ -146,7 +154,7 @@ use ark_std::test_rng;
 		let nullifier = Fq::rand(rng);
 
 		// Public data
-        let chain_id = Fq::from(1u32);
+		let chain_id = Fq::from(1u32);
 		let arbitrary_data = Fq::rand(rng);
 		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
 		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
@@ -167,23 +175,24 @@ use ark_std::test_rng;
 		)
 		.unwrap();
 
-        let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
 		roots[0] = tree.root();
 
 		// Path
 		let path = tree.generate_membership_proof(last_index as u64);
 
 		// Create AnchorCircuit
-		let mut anchor = AnchorCircuit::<Bn254, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
-            chain_id,
-			secret,
-			nullifier,
-			nullifier_hash,
-			path,
-			roots,
-			arbitrary_data,
-			poseidon_native,
-		);
+		let mut anchor =
+			AnchorCircuit::<Bn254, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
+				chain_id,
+				secret,
+				nullifier,
+				nullifier_hash,
+				path,
+				roots,
+				arbitrary_data,
+				poseidon_native,
+			);
 
 		let res = gadget_tester::<Bn254, JubjubParameters, _>(&mut anchor, 1 << 17);
 		assert!(res.is_ok(), "{:?}", res.err().unwrap());
@@ -202,7 +211,7 @@ use ark_std::test_rng;
 		let nullifier = Fq::rand(rng);
 
 		// Public data
-        let chain_id = Fq::from(1u32);
+		let chain_id = Fq::from(1u32);
 		let arbitrary_data = Fq::rand(rng);
 		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
 		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
@@ -222,25 +231,26 @@ use ark_std::test_rng;
 			&[0u8; 32],
 		)
 		.unwrap();
-        let mut root = tree.root();
+		let mut root = tree.root();
 		let bad_root = root.double();
-        let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
 		roots[0] = bad_root;
 
 		// Path
 		let path = tree.generate_membership_proof(last_index as u64);
 
 		// Create AnchorCircuit
-		let mut anchor = AnchorCircuit::<Bn254, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
-            chain_id,
-			secret,
-			nullifier,
-			nullifier_hash,
-			path,
-			roots,
-			arbitrary_data,
-			poseidon_native,
-		);
+		let mut anchor =
+			AnchorCircuit::<Bn254, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
+				chain_id,
+				secret,
+				nullifier,
+				nullifier_hash,
+				path,
+				roots,
+				arbitrary_data,
+				poseidon_native,
+			);
 
 		// Fill a composer to extract the public_inputs
 		let mut composer = StandardComposer::<Bn254, JubjubParameters>::new();
@@ -252,10 +262,7 @@ use ark_std::test_rng;
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
 		let proof = {
 			// Create a prover struct
-			let mut prover =
-				Prover::<Bn254, JubjubParameters>::new(
-					b"mixer",
-				);
+			let mut prover = Prover::<Bn254, JubjubParameters>::new(b"mixer");
 			prover.key_transcript(b"key", b"additional seed information");
 			// Add gadgets
 			let _ = anchor.gadget(prover.mut_cs());
@@ -284,10 +291,12 @@ use ark_std::test_rng;
 		verifier.preprocess(&ck.powers()).unwrap();
 
 		// Verify proof
-        let mut vk_bytes = Vec::new();
-        sonic_pc::VerifierKey::<Bn254>::serialize(&vk, &mut vk_bytes).unwrap();
-        let kzg_vk = kzg10::VerifierKey::<Bn254>::deserialize(&vk_bytes[..]).unwrap();
-		let res = verifier.verify(&proof, &kzg_vk, &public_inputs).unwrap_err();
+		let mut vk_bytes = Vec::new();
+		sonic_pc::VerifierKey::<Bn254>::serialize(&vk, &mut vk_bytes).unwrap();
+		let kzg_vk = kzg10::VerifierKey::<Bn254>::deserialize(&vk_bytes[..]).unwrap();
+		let res = verifier
+			.verify(&proof, &kzg_vk, &public_inputs)
+			.unwrap_err();
 		match res {
 			Error::ProofVerificationError => (),
 			err => panic!("Unexpected error: {:?}", err),
@@ -307,7 +316,7 @@ use ark_std::test_rng;
 		let nullifier = Fq::rand(rng);
 
 		// Public data
-        let chain_id = Fq::from(1u32);
+		let chain_id = Fq::from(1u32);
 		let arbitrary_data = Fq::rand(rng);
 		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
 		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
@@ -327,8 +336,8 @@ use ark_std::test_rng;
 			&[0u8; 32],
 		)
 		.unwrap();
-        let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-        roots[0] = tree.root();
+		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+		roots[0] = tree.root();
 		// Path
 		let path = tree.generate_membership_proof(last_index as u64);
 
@@ -336,16 +345,17 @@ use ark_std::test_rng;
 		let bad_secret = secret.double();
 
 		// Create AnchorCircuit
-		let mut anchor = AnchorCircuit::<Bn254, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
-            chain_id,
-			bad_secret,
-			nullifier,
-			nullifier_hash,
-			path,
-			roots,
-			arbitrary_data,
-			poseidon_native,
-		);
+		let mut anchor =
+			AnchorCircuit::<Bn254, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
+				chain_id,
+				bad_secret,
+				nullifier,
+				nullifier_hash,
+				path,
+				roots,
+				arbitrary_data,
+				poseidon_native,
+			);
 
 		// Fill a composer to extract the public_inputs
 		let mut composer = StandardComposer::<Bn254, JubjubParameters>::new();
@@ -357,10 +367,7 @@ use ark_std::test_rng;
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
 		let proof = {
 			// Create a prover struct
-			let mut prover =
-				Prover::<Bn254, JubjubParameters>::new(
-					b"mixer",
-				);
+			let mut prover = Prover::<Bn254, JubjubParameters>::new(b"mixer");
 			prover.key_transcript(b"key", b"additional seed information");
 			// Add gadgets
 			let _ = anchor.gadget(prover.mut_cs());
@@ -389,10 +396,12 @@ use ark_std::test_rng;
 		verifier.preprocess(&ck.powers()).unwrap();
 
 		// Verify proof
-        let mut vk_bytes = Vec::new();
-        sonic_pc::VerifierKey::<Bn254>::serialize(&vk, &mut vk_bytes).unwrap();
-        let kzg_vk = kzg10::VerifierKey::<Bn254>::deserialize(&vk_bytes[..]).unwrap();
-		let res = verifier.verify(&proof, &kzg_vk, &public_inputs).unwrap_err();
+		let mut vk_bytes = Vec::new();
+		sonic_pc::VerifierKey::<Bn254>::serialize(&vk, &mut vk_bytes).unwrap();
+		let kzg_vk = kzg10::VerifierKey::<Bn254>::deserialize(&vk_bytes[..]).unwrap();
+		let res = verifier
+			.verify(&proof, &kzg_vk, &public_inputs)
+			.unwrap_err();
 		match res {
 			Error::ProofVerificationError => (),
 			err => panic!("Unexpected error: {:?}", err),
@@ -412,7 +421,7 @@ use ark_std::test_rng;
 		let nullifier = Fq::rand(rng);
 
 		// Public data
-        let chain_id = Fq::from(1u32);
+		let chain_id = Fq::from(1u32);
 		let arbitrary_data = Fq::rand(rng);
 		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
 		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
@@ -432,8 +441,8 @@ use ark_std::test_rng;
 			&[0u8; 32],
 		)
 		.unwrap();
-        let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-        roots[0] = tree.root();
+		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+		roots[0] = tree.root();
 
 		// Path
 		let path = tree.generate_membership_proof(last_index as u64);
@@ -442,16 +451,17 @@ use ark_std::test_rng;
 		let bad_nullifier = nullifier.double();
 
 		// Create AnchorCircuit
-		let mut anchor = AnchorCircuit::<Bn254, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
-            chain_id,
-			secret,
-			bad_nullifier,
-			nullifier_hash,
-			path,
-			roots,
-			arbitrary_data,
-			poseidon_native,
-		);
+		let mut anchor =
+			AnchorCircuit::<Bn254, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
+				chain_id,
+				secret,
+				bad_nullifier,
+				nullifier_hash,
+				path,
+				roots,
+				arbitrary_data,
+				poseidon_native,
+			);
 
 		// Fill a composer to extract the public_inputs
 		let mut composer = StandardComposer::<Bn254, JubjubParameters>::new();
@@ -463,10 +473,7 @@ use ark_std::test_rng;
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
 		let proof = {
 			// Create a prover struct
-			let mut prover =
-				Prover::<Bn254, JubjubParameters>::new(
-					b"mixer",
-				);
+			let mut prover = Prover::<Bn254, JubjubParameters>::new(b"mixer");
 			prover.key_transcript(b"key", b"additional seed information");
 			// Add gadgets
 			let _ = anchor.gadget(prover.mut_cs());
@@ -495,10 +502,12 @@ use ark_std::test_rng;
 		verifier.preprocess(&ck.powers()).unwrap();
 
 		// Verify proof
-        let mut vk_bytes = Vec::new();
-        sonic_pc::VerifierKey::<Bn254>::serialize(&vk, &mut vk_bytes).unwrap();
-        let kzg_vk = kzg10::VerifierKey::<Bn254>::deserialize(&vk_bytes[..]).unwrap();
-		let res = verifier.verify(&proof, &kzg_vk, &public_inputs).unwrap_err();
+		let mut vk_bytes = Vec::new();
+		sonic_pc::VerifierKey::<Bn254>::serialize(&vk, &mut vk_bytes).unwrap();
+		let kzg_vk = kzg10::VerifierKey::<Bn254>::deserialize(&vk_bytes[..]).unwrap();
+		let res = verifier
+			.verify(&proof, &kzg_vk, &public_inputs)
+			.unwrap_err();
 		match res {
 			Error::ProofVerificationError => (),
 			err => panic!("Unexpected error: {:?}", err),
@@ -518,7 +527,7 @@ use ark_std::test_rng;
 		let nullifier = Fq::rand(rng);
 
 		// Public data
-        let chain_id = Fq::from(1u32);
+		let chain_id = Fq::from(1u32);
 		let arbitrary_data = Fq::rand(rng);
 		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
 		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
@@ -538,23 +547,24 @@ use ark_std::test_rng;
 			&[0u8; 32],
 		)
 		.unwrap();
-        let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-        roots[0] = tree.root();
+		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+		roots[0] = tree.root();
 
 		// An incorrect path to use below
 		let bad_path = tree.generate_membership_proof((last_index as u64) - 1);
 
 		// Create AnchorCircuit
-		let mut anchor = AnchorCircuit::<Bn254, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
-            chain_id,
-			secret,
-			nullifier,
-			nullifier_hash,
-			bad_path,
-			roots,
-			arbitrary_data,
-			poseidon_native,
-		);
+		let mut anchor =
+			AnchorCircuit::<Bn254, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
+				chain_id,
+				secret,
+				nullifier,
+				nullifier_hash,
+				bad_path,
+				roots,
+				arbitrary_data,
+				poseidon_native,
+			);
 
 		// Fill a composer to extract the public_inputs
 		let mut composer = StandardComposer::<Bn254, JubjubParameters>::new();
@@ -566,10 +576,7 @@ use ark_std::test_rng;
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
 		let proof = {
 			// Create a prover struct
-			let mut prover =
-				Prover::<Bn254, JubjubParameters>::new(
-					b"mixer",
-				);
+			let mut prover = Prover::<Bn254, JubjubParameters>::new(b"mixer");
 			prover.key_transcript(b"key", b"additional seed information");
 			// Add gadgets
 			let _ = anchor.gadget(prover.mut_cs());
@@ -598,10 +605,12 @@ use ark_std::test_rng;
 		verifier.preprocess(&ck.powers()).unwrap();
 
 		// Verify proof
-        let mut vk_bytes = Vec::new();
-        sonic_pc::VerifierKey::<Bn254>::serialize(&vk, &mut vk_bytes).unwrap();
-        let kzg_vk = kzg10::VerifierKey::<Bn254>::deserialize(&vk_bytes[..]).unwrap();
-		let res = verifier.verify(&proof, &kzg_vk, &public_inputs).unwrap_err();
+		let mut vk_bytes = Vec::new();
+		sonic_pc::VerifierKey::<Bn254>::serialize(&vk, &mut vk_bytes).unwrap();
+		let kzg_vk = kzg10::VerifierKey::<Bn254>::deserialize(&vk_bytes[..]).unwrap();
+		let res = verifier
+			.verify(&proof, &kzg_vk, &public_inputs)
+			.unwrap_err();
 		match res {
 			Error::ProofVerificationError => (),
 			err => panic!("Unexpected error: {:?}", err),
@@ -621,7 +630,7 @@ use ark_std::test_rng;
 		let nullifier = Fq::rand(rng);
 
 		// Public data
-        let chain_id = Fq::from(1u32);
+		let chain_id = Fq::from(1u32);
 		let arbitrary_data = Fq::rand(rng);
 		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
 		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
@@ -641,8 +650,8 @@ use ark_std::test_rng;
 			&[0u8; 32],
 		)
 		.unwrap();
-        let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-        roots[0] = tree.root();
+		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+		roots[0] = tree.root();
 
 		// Path
 		let path = tree.generate_membership_proof(last_index as u64);
@@ -651,16 +660,17 @@ use ark_std::test_rng;
 		let bad_nullifier_hash = nullifier_hash.double();
 
 		// Create AnchorCircuit
-		let mut anchor = AnchorCircuit::<Bn254, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
-            chain_id,
-			secret,
-			nullifier,
-			bad_nullifier_hash,
-			path,
-			roots,
-			arbitrary_data,
-			poseidon_native,
-		);
+		let mut anchor =
+			AnchorCircuit::<Bn254, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
+				chain_id,
+				secret,
+				nullifier,
+				bad_nullifier_hash,
+				path,
+				roots,
+				arbitrary_data,
+				poseidon_native,
+			);
 
 		// Fill a composer to extract the public_inputs
 		let mut composer = StandardComposer::<Bn254, JubjubParameters>::new();
@@ -672,10 +682,7 @@ use ark_std::test_rng;
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
 		let proof = {
 			// Create a prover struct
-			let mut prover =
-				Prover::<Bn254, JubjubParameters>::new(
-					b"mixer",
-				);
+			let mut prover = Prover::<Bn254, JubjubParameters>::new(b"mixer");
 			prover.key_transcript(b"key", b"additional seed information");
 			// Add gadgets
 			let _ = anchor.gadget(prover.mut_cs());
@@ -704,10 +711,12 @@ use ark_std::test_rng;
 		verifier.preprocess(&ck.powers()).unwrap();
 
 		// Verify proof
-        let mut vk_bytes = Vec::new();
-        sonic_pc::VerifierKey::<Bn254>::serialize(&vk, &mut vk_bytes).unwrap();
-        let kzg_vk = kzg10::VerifierKey::<Bn254>::deserialize(&vk_bytes[..]).unwrap();
-		let res = verifier.verify(&proof, &kzg_vk, &public_inputs).unwrap_err();
+		let mut vk_bytes = Vec::new();
+		sonic_pc::VerifierKey::<Bn254>::serialize(&vk, &mut vk_bytes).unwrap();
+		let kzg_vk = kzg10::VerifierKey::<Bn254>::deserialize(&vk_bytes[..]).unwrap();
+		let res = verifier
+			.verify(&proof, &kzg_vk, &public_inputs)
+			.unwrap_err();
 		match res {
 			Error::ProofVerificationError => (),
 			err => panic!("Unexpected error: {:?}", err),
@@ -727,7 +736,7 @@ use ark_std::test_rng;
 		let nullifier = Fq::rand(rng);
 
 		// Public data
-        let chain_id = Fq::from(1u32);
+		let chain_id = Fq::from(1u32);
 		let arbitrary_data = Fq::rand(rng);
 		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
 		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
@@ -747,23 +756,24 @@ use ark_std::test_rng;
 			&[0u8; 32],
 		)
 		.unwrap();
-        let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-        roots[0] = tree.root();
+		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+		roots[0] = tree.root();
 
 		// Path
 		let path = tree.generate_membership_proof(last_index as u64);
 
 		// Create AnchorCircuit
-		let mut anchor = AnchorCircuit::<Bn254, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
-            chain_id,
-			secret,
-			nullifier,
-			nullifier_hash,
-			path,
-			roots,
-			arbitrary_data,
-			poseidon_native,
-		);
+		let mut anchor =
+			AnchorCircuit::<Bn254, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
+				chain_id,
+				secret,
+				nullifier,
+				nullifier_hash,
+				path,
+				roots,
+				arbitrary_data,
+				poseidon_native,
+			);
 
 		// Fill a composer to extract the public_inputs
 		let mut composer = StandardComposer::<Bn254, JubjubParameters>::new();
@@ -775,10 +785,7 @@ use ark_std::test_rng;
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
 		let proof = {
 			// Create a prover struct
-			let mut prover =
-				Prover::<Bn254, JubjubParameters>::new(
-					b"mixer",
-				);
+			let mut prover = Prover::<Bn254, JubjubParameters>::new(b"mixer");
 			prover.key_transcript(b"key", b"additional seed information");
 			// Add gadgets
 			let _ = anchor.gadget(prover.mut_cs());
@@ -812,10 +819,12 @@ use ark_std::test_rng;
 		public_inputs[5].double_in_place();
 
 		// Verify proof
-        let mut vk_bytes = Vec::new();
-        sonic_pc::VerifierKey::<Bn254>::serialize(&vk, &mut vk_bytes).unwrap();
-        let kzg_vk = kzg10::VerifierKey::<Bn254>::deserialize(&vk_bytes[..]).unwrap();
-		let res = verifier.verify(&proof, &kzg_vk, &public_inputs).unwrap_err();
+		let mut vk_bytes = Vec::new();
+		sonic_pc::VerifierKey::<Bn254>::serialize(&vk, &mut vk_bytes).unwrap();
+		let kzg_vk = kzg10::VerifierKey::<Bn254>::deserialize(&vk_bytes[..]).unwrap();
+		let res = verifier
+			.verify(&proof, &kzg_vk, &public_inputs)
+			.unwrap_err();
 		match res {
 			Error::ProofVerificationError => (),
 			err => panic!("Unexpected error: {:?}", err),

--- a/arkworks-plonk-circuits/src/anchor/mod.rs
+++ b/arkworks-plonk-circuits/src/anchor/mod.rs
@@ -134,7 +134,7 @@ use ark_std::test_rng;
     const BRIDGE_SIZE: usize = 2;
 
 	#[test]
-	fn should_verify_correct_mixer_plonk() {
+	fn should_verify_correct_anchor_plonk() {
 		let rng = &mut test_rng();
 		let curve = Curve::Bn254;
 
@@ -807,7 +807,7 @@ use ark_std::test_rng;
 		verifier.preprocess(&ck.powers()).unwrap();
 
 		// The arbitrary data is stored at index 5 of the public input vector:
-		assert_eq!(arbitrary_data, public_inputs[5]);
+		assert_eq!(arbitrary_data, public_inputs[7]);
 		// Modify the arbitrary data so that prover/verifier disagree
 		public_inputs[5].double_in_place();
 

--- a/arkworks-plonk-circuits/src/lib.rs
+++ b/arkworks-plonk-circuits/src/lib.rs
@@ -5,3 +5,4 @@ pub mod mixer;
 pub mod poseidon;
 pub mod set_membership;
 pub mod utils;
+pub mod anchor;

--- a/arkworks-plonk-circuits/src/lib.rs
+++ b/arkworks-plonk-circuits/src/lib.rs
@@ -1,8 +1,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+pub mod anchor;
 pub mod merkle_tree;
 pub mod mixer;
 pub mod poseidon;
 pub mod set_membership;
 pub mod utils;
-pub mod anchor;

--- a/arkworks-plonk-circuits/src/merkle_tree/mod.rs
+++ b/arkworks-plonk-circuits/src/merkle_tree/mod.rs
@@ -1,7 +1,7 @@
 use crate::poseidon::poseidon::FieldHasherGadget;
 use ark_ec::{models::TEModelParameters, PairingEngine};
 use ark_ff::Field;
-use ark_std::{One, Zero, marker::PhantomData};
+use ark_std::{marker::PhantomData, One, Zero};
 use arkworks_gadgets::merkle_tree::simple_merkle::Path;
 use plonk_core::{constraint_system::StandardComposer, error::Error, prelude::Variable};
 
@@ -105,13 +105,16 @@ impl<
 			// Check if previous hash is a left node
 			let previous_is_left = composer.is_eq_with_output(previous_hash, *left_hash);
 			right_value = composer.arithmetic_gate(|gate| {
-				gate.witness(index, two_power, None).add(E::Fr::one(), E::Fr::one())
+				gate.witness(index, two_power, None)
+					.add(E::Fr::one(), E::Fr::one())
 			});
 
 			// Assign index based on whether prev hash is left or right
 			index = composer.conditional_select(previous_is_left, index, right_value);
-			two_power = composer
-				.arithmetic_gate(|gate| gate.witness(two_power, one, None).mul(E::Fr::one().double()));
+			two_power = composer.arithmetic_gate(|gate| {
+				gate.witness(two_power, one, None)
+					.mul(E::Fr::one().double())
+			});
 
 			previous_hash = hasher.hash_two(composer, left_hash, right_hash)?;
 		}
@@ -127,7 +130,7 @@ mod test {
 	use super::*;
 	use crate::poseidon::poseidon::{FieldHasherGadget, PoseidonGadget};
 	use ark_bn254::{Bn254, Fr as Bn254Fr};
-	use ark_ec::{TEModelParameters, PairingEngine};
+	use ark_ec::{PairingEngine, TEModelParameters};
 	use ark_ed_on_bn254::{EdwardsParameters as JubjubParameters, Fq};
 	use ark_ff::PrimeField;
 	use ark_poly::polynomial::univariate::DensePolynomial;
@@ -214,9 +217,7 @@ mod test {
 		let u_params: UniversalParams<Bn254> =
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 14, None, rng).unwrap();
 
-		let (pk, vd) = test_circuit
-			.compile(&u_params)
-			.unwrap();
+		let (pk, vd) = test_circuit.compile(&u_params).unwrap();
 
 		// PROVER
 		let proof = test_circuit.gen_proof(&u_params, pk, b"SMT Test").unwrap();
@@ -230,10 +231,13 @@ mod test {
 			&u_params,
 			key,
 			&proof,
-			&public_inputs.iter().map(|pi| {
-				let temp = *pi;
-				temp.into_pi()
-			}).collect::<Vec<_>>()[..],
+			&public_inputs
+				.iter()
+				.map(|pi| {
+					let temp = *pi;
+					temp.into_pi()
+				})
+				.collect::<Vec<_>>()[..],
 			&pi_pos,
 			b"SMT Test",
 		)
@@ -314,9 +318,7 @@ mod test {
 		let u_params: UniversalParams<Bn254> =
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 15, None, rng).unwrap();
 
-		let (pk, vd) = test_circuit
-			.compile(&u_params)
-			.unwrap();
+		let (pk, vd) = test_circuit.compile(&u_params).unwrap();
 
 		// PROVER
 		let proof = test_circuit
@@ -332,10 +334,13 @@ mod test {
 			&u_params,
 			key,
 			&proof,
-			&public_inputs.iter().map(|pi| {
-				let temp = *pi;
-				temp.into_pi()
-			}).collect::<Vec<_>>()[..],
+			&public_inputs
+				.iter()
+				.map(|pi| {
+					let temp = *pi;
+					temp.into_pi()
+				})
+				.collect::<Vec<_>>()[..],
 			&pi_pos,
 			b"SMTIndex Test",
 		)
@@ -428,9 +433,7 @@ mod test {
 		let u_params: UniversalParams<Bn254> =
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 17, None, rng).unwrap();
 
-		let (pk, vd) = test_circuit
-			.compile(&u_params)
-			.unwrap();
+		let (pk, vd) = test_circuit.compile(&u_params).unwrap();
 
 		// PROVER
 		let proof = test_circuit
@@ -446,10 +449,13 @@ mod test {
 			&u_params,
 			key,
 			&proof,
-			&public_inputs.iter().map(|pi| {
-				let temp = *pi;
-				temp.into_pi()
-			}).collect::<Vec<_>>()[..],
+			&public_inputs
+				.iter()
+				.map(|pi| {
+					let temp = *pi;
+					temp.into_pi()
+				})
+				.collect::<Vec<_>>()[..],
 			&pi_pos,
 			b"SMTIndex Test",
 		)
@@ -534,9 +540,7 @@ mod test {
 		let u_params: UniversalParams<Bn254> =
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 17, None, rng).unwrap();
 
-		let (pk, vd) = test_circuit
-			.compile(&u_params)
-			.unwrap();
+		let (pk, vd) = test_circuit.compile(&u_params).unwrap();
 
 		// PROVER
 		let proof = test_circuit.gen_proof(&u_params, pk, b"SMT Test").unwrap();
@@ -550,10 +554,13 @@ mod test {
 			&u_params,
 			key,
 			&proof,
-			&public_inputs.iter().map(|pi| {
-				let temp = *pi;
-				temp.into_pi()
-			}).collect::<Vec<_>>()[..],
+			&public_inputs
+				.iter()
+				.map(|pi| {
+					let temp = *pi;
+					temp.into_pi()
+				})
+				.collect::<Vec<_>>()[..],
 			&pi_pos,
 			b"SMTIndex Test",
 		)
@@ -638,9 +645,7 @@ mod test {
 		let u_params: UniversalParams<Bn254> =
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 17, None, rng).unwrap();
 
-		let (pk, vd) = test_circuit
-			.compile(&u_params)
-			.unwrap();
+		let (pk, vd) = test_circuit.compile(&u_params).unwrap();
 
 		// PROVER
 		let proof = test_circuit.gen_proof(&u_params, pk, b"SMT Test").unwrap();
@@ -654,10 +659,13 @@ mod test {
 			&u_params,
 			key,
 			&proof,
-			&public_inputs.iter().map(|pi| {
-				let temp = *pi;
-				temp.into_pi()
-			}).collect::<Vec<_>>()[..],
+			&public_inputs
+				.iter()
+				.map(|pi| {
+					let temp = *pi;
+					temp.into_pi()
+				})
+				.collect::<Vec<_>>()[..],
 			&pi_pos,
 			b"SMTIndex Test",
 		)

--- a/arkworks-plonk-circuits/src/mixer/mod.rs
+++ b/arkworks-plonk-circuits/src/mixer/mod.rs
@@ -1,6 +1,6 @@
 use crate::{merkle_tree::PathGadget, poseidon::poseidon::FieldHasherGadget};
 use ark_ec::{models::TEModelParameters, PairingEngine};
-use ark_std::{Zero, One};
+use ark_std::{One, Zero};
 use arkworks_gadgets::merkle_tree::simple_merkle::Path;
 use plonk_core::{
 	circuit::Circuit, constraint_system::StandardComposer, error::Error, prelude::Variable,
@@ -100,7 +100,10 @@ where
 
 /// Add a variable to a circuit and constrain it to a public input value that
 /// is expected to be different in each instance of the circuit.
-pub fn add_public_input_variable<E, P>(composer: &mut StandardComposer<E, P>, value: E::Fr) -> Variable
+pub fn add_public_input_variable<E, P>(
+	composer: &mut StandardComposer<E, P>,
+	value: E::Fr,
+) -> Variable
 where
 	E: PairingEngine,
 	P: TEModelParameters<BaseField = E::Fr>,
@@ -128,8 +131,12 @@ mod test {
 	use ark_ed_on_bn254::{EdwardsParameters as JubjubParameters, Fq};
 	use ark_ff::Field;
 	use ark_poly::polynomial::univariate::DensePolynomial;
-	use ark_poly_commit::{kzg10::{UniversalParams, self}, sonic_pc::{SonicKZG10, self}, PolynomialCommitment};
-	use ark_serialize::{CanonicalSerialize, CanonicalDeserialize};
+	use ark_poly_commit::{
+		kzg10::{self, UniversalParams},
+		sonic_pc::{self, SonicKZG10},
+		PolynomialCommitment,
+	};
+	use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 	use ark_std::test_rng;
 	use arkworks_gadgets::{
 		ark_std::UniformRand,
@@ -255,10 +262,7 @@ mod test {
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
 		let proof = {
 			// Create a prover struct
-			let mut prover =
-				Prover::<Bn254, JubjubParameters>::new(
-					b"mixer",
-				);
+			let mut prover = Prover::<Bn254, JubjubParameters>::new(b"mixer");
 			prover.key_transcript(b"key", b"additional seed information");
 			// Add gadgets
 			let _ = mixer.gadget(prover.mut_cs());
@@ -287,9 +291,11 @@ mod test {
 		verifier.preprocess(&ck.powers()).unwrap();
 
 		let mut vk_bytes = Vec::new();
-        sonic_pc::VerifierKey::<Bn254>::serialize(&vk, &mut vk_bytes).unwrap();
-        let kzg_vk = kzg10::VerifierKey::<Bn254>::deserialize(&vk_bytes[..]).unwrap();
-		let res = verifier.verify(&proof, &kzg_vk, &public_inputs).unwrap_err();
+		sonic_pc::VerifierKey::<Bn254>::serialize(&vk, &mut vk_bytes).unwrap();
+		let kzg_vk = kzg10::VerifierKey::<Bn254>::deserialize(&vk_bytes[..]).unwrap();
+		let res = verifier
+			.verify(&proof, &kzg_vk, &public_inputs)
+			.unwrap_err();
 		match res {
 			Error::ProofVerificationError => (),
 			err => panic!("Unexpected error: {:?}", err),
@@ -357,10 +363,7 @@ mod test {
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
 		let proof = {
 			// Create a prover struct
-			let mut prover =
-				Prover::<Bn254, JubjubParameters>::new(
-					b"mixer",
-				);
+			let mut prover = Prover::<Bn254, JubjubParameters>::new(b"mixer");
 			prover.key_transcript(b"key", b"additional seed information");
 			// Add gadgets
 			let _ = mixer.gadget(prover.mut_cs());
@@ -389,9 +392,11 @@ mod test {
 		verifier.preprocess(&ck.powers()).unwrap();
 
 		let mut vk_bytes = Vec::new();
-        sonic_pc::VerifierKey::<Bn254>::serialize(&vk, &mut vk_bytes).unwrap();
-        let kzg_vk = kzg10::VerifierKey::<Bn254>::deserialize(&vk_bytes[..]).unwrap();
-		let res = verifier.verify(&proof, &kzg_vk, &public_inputs).unwrap_err();
+		sonic_pc::VerifierKey::<Bn254>::serialize(&vk, &mut vk_bytes).unwrap();
+		let kzg_vk = kzg10::VerifierKey::<Bn254>::deserialize(&vk_bytes[..]).unwrap();
+		let res = verifier
+			.verify(&proof, &kzg_vk, &public_inputs)
+			.unwrap_err();
 		match res {
 			Error::ProofVerificationError => (),
 			err => panic!("Unexpected error: {:?}", err),
@@ -459,10 +464,7 @@ mod test {
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
 		let proof = {
 			// Create a prover struct
-			let mut prover =
-				Prover::<Bn254, JubjubParameters>::new(
-					b"mixer",
-				);
+			let mut prover = Prover::<Bn254, JubjubParameters>::new(b"mixer");
 			prover.key_transcript(b"key", b"additional seed information");
 			// Add gadgets
 			let _ = mixer.gadget(prover.mut_cs());
@@ -491,9 +493,11 @@ mod test {
 		verifier.preprocess(&ck.powers()).unwrap();
 
 		let mut vk_bytes = Vec::new();
-        sonic_pc::VerifierKey::<Bn254>::serialize(&vk, &mut vk_bytes).unwrap();
-        let kzg_vk = kzg10::VerifierKey::<Bn254>::deserialize(&vk_bytes[..]).unwrap();
-		let res = verifier.verify(&proof, &kzg_vk, &public_inputs).unwrap_err();
+		sonic_pc::VerifierKey::<Bn254>::serialize(&vk, &mut vk_bytes).unwrap();
+		let kzg_vk = kzg10::VerifierKey::<Bn254>::deserialize(&vk_bytes[..]).unwrap();
+		let res = verifier
+			.verify(&proof, &kzg_vk, &public_inputs)
+			.unwrap_err();
 		match res {
 			Error::ProofVerificationError => (),
 			err => panic!("Unexpected error: {:?}", err),
@@ -558,10 +562,7 @@ mod test {
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
 		let proof = {
 			// Create a prover struct
-			let mut prover =
-				Prover::<Bn254, JubjubParameters>::new(
-					b"mixer",
-				);
+			let mut prover = Prover::<Bn254, JubjubParameters>::new(b"mixer");
 			prover.key_transcript(b"key", b"additional seed information");
 			// Add gadgets
 			let _ = mixer.gadget(prover.mut_cs());
@@ -590,9 +591,11 @@ mod test {
 		verifier.preprocess(&ck.powers()).unwrap();
 
 		let mut vk_bytes = Vec::new();
-        sonic_pc::VerifierKey::<Bn254>::serialize(&vk, &mut vk_bytes).unwrap();
-        let kzg_vk = kzg10::VerifierKey::<Bn254>::deserialize(&vk_bytes[..]).unwrap();
-		let res = verifier.verify(&proof, &kzg_vk, &public_inputs).unwrap_err();
+		sonic_pc::VerifierKey::<Bn254>::serialize(&vk, &mut vk_bytes).unwrap();
+		let kzg_vk = kzg10::VerifierKey::<Bn254>::deserialize(&vk_bytes[..]).unwrap();
+		let res = verifier
+			.verify(&proof, &kzg_vk, &public_inputs)
+			.unwrap_err();
 		match res {
 			Error::ProofVerificationError => (),
 			err => panic!("Unexpected error: {:?}", err),
@@ -660,10 +663,7 @@ mod test {
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
 		let proof = {
 			// Create a prover struct
-			let mut prover =
-				Prover::<Bn254, JubjubParameters>::new(
-					b"mixer",
-				);
+			let mut prover = Prover::<Bn254, JubjubParameters>::new(b"mixer");
 			prover.key_transcript(b"key", b"additional seed information");
 			// Add gadgets
 			let _ = mixer.gadget(prover.mut_cs());
@@ -692,9 +692,11 @@ mod test {
 		verifier.preprocess(&ck.powers()).unwrap();
 
 		let mut vk_bytes = Vec::new();
-        sonic_pc::VerifierKey::<Bn254>::serialize(&vk, &mut vk_bytes).unwrap();
-        let kzg_vk = kzg10::VerifierKey::<Bn254>::deserialize(&vk_bytes[..]).unwrap();
-		let res = verifier.verify(&proof, &kzg_vk, &public_inputs).unwrap_err();
+		sonic_pc::VerifierKey::<Bn254>::serialize(&vk, &mut vk_bytes).unwrap();
+		let kzg_vk = kzg10::VerifierKey::<Bn254>::deserialize(&vk_bytes[..]).unwrap();
+		let res = verifier
+			.verify(&proof, &kzg_vk, &public_inputs)
+			.unwrap_err();
 		match res {
 			Error::ProofVerificationError => (),
 			err => panic!("Unexpected error: {:?}", err),
@@ -759,10 +761,7 @@ mod test {
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
 		let proof = {
 			// Create a prover struct
-			let mut prover =
-				Prover::<Bn254, JubjubParameters>::new(
-					b"mixer",
-				);
+			let mut prover = Prover::<Bn254, JubjubParameters>::new(b"mixer");
 			prover.key_transcript(b"key", b"additional seed information");
 			// Add gadgets
 			let _ = mixer.gadget(prover.mut_cs());
@@ -796,9 +795,11 @@ mod test {
 		public_inputs[5].double_in_place();
 
 		let mut vk_bytes = Vec::new();
-        sonic_pc::VerifierKey::<Bn254>::serialize(&vk, &mut vk_bytes).unwrap();
-        let kzg_vk = kzg10::VerifierKey::<Bn254>::deserialize(&vk_bytes[..]).unwrap();
-		let res = verifier.verify(&proof, &kzg_vk, &public_inputs).unwrap_err();
+		sonic_pc::VerifierKey::<Bn254>::serialize(&vk, &mut vk_bytes).unwrap();
+		let kzg_vk = kzg10::VerifierKey::<Bn254>::deserialize(&vk_bytes[..]).unwrap();
+		let res = verifier
+			.verify(&proof, &kzg_vk, &public_inputs)
+			.unwrap_err();
 		match res {
 			Error::ProofVerificationError => (),
 			err => panic!("Unexpected error: {:?}", err),

--- a/arkworks-plonk-circuits/src/poseidon/poseidon.rs
+++ b/arkworks-plonk-circuits/src/poseidon/poseidon.rs
@@ -104,8 +104,10 @@ impl<E: PairingEngine, P: TEModelParameters<BaseField = E::Fr>> FieldHasherGadge
 		for r in 0..nr {
 			state.iter_mut().enumerate().for_each(|(i, a)| {
 				let c_temp = self.params.round_keys[(r * width + i)];
-				*a = composer
-					.arithmetic_gate(|gate| gate.witness(*a, c_temp, None).add(E::Fr::one(), E::Fr::one()));
+				*a = composer.arithmetic_gate(|gate| {
+					gate.witness(*a, c_temp, None)
+						.add(E::Fr::one(), E::Fr::one())
+				});
 			});
 
 			let half_rounds = full_rounds / 2;
@@ -130,11 +132,13 @@ impl<E: PairingEngine, P: TEModelParameters<BaseField = E::Fr>> FieldHasherGadge
 						.fold(composer.zero_var(), |acc, (j, a)| {
 							let m = &self.params.mds_matrix[i][j];
 
-							let mul_result = composer
-								.arithmetic_gate(|gate| gate.witness(*a, *m, None).mul(E::Fr::one()));
+							let mul_result = composer.arithmetic_gate(|gate| {
+								gate.witness(*a, *m, None).mul(E::Fr::one())
+							});
 
 							let add_result = composer.arithmetic_gate(|gate| {
-								gate.witness(acc, mul_result, None).add(E::Fr::one(), E::Fr::one())
+								gate.witness(acc, mul_result, None)
+									.add(E::Fr::one(), E::Fr::one())
 							});
 
 							add_result
@@ -187,8 +191,11 @@ mod tests {
 		hasher: HG::Native,
 	}
 
-	impl<E: PairingEngine, P: TEModelParameters<BaseField = E::Fr>, HG: FieldHasherGadget<E, P>>
-		Circuit<E, P> for TestCircuit<E, P, HG>
+	impl<
+			E: PairingEngine,
+			P: TEModelParameters<BaseField = E::Fr>,
+			HG: FieldHasherGadget<E, P>,
+		> Circuit<E, P> for TestCircuit<E, P, HG>
 	{
 		const CIRCUIT_ID: [u8; 32] = [0xff; 32];
 
@@ -241,9 +248,7 @@ mod tests {
 		let u_params: UniversalParams<Bn254> =
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 13, None, rng).unwrap();
 
-		let (pk, vd) = test_circuit
-			.compile(&u_params)
-			.unwrap();
+		let (pk, vd) = test_circuit.compile(&u_params).unwrap();
 
 		// PROVER
 		let proof = test_circuit
@@ -259,10 +264,13 @@ mod tests {
 			&u_params,
 			key,
 			&proof,
-			&public_inputs.iter().map(|pi| {
-				let temp = *pi;
-				temp.into_pi()
-			}).collect::<Vec<_>>()[..],
+			&public_inputs
+				.iter()
+				.map(|pi| {
+					let temp = *pi;
+					temp.into_pi()
+				})
+				.collect::<Vec<_>>()[..],
 			&pi_pos,
 			b"Poseidon Test",
 		)

--- a/arkworks-plonk-circuits/src/poseidon/sbox.rs
+++ b/arkworks-plonk-circuits/src/poseidon/sbox.rs
@@ -1,8 +1,7 @@
 use ark_ec::{PairingEngine, TEModelParameters};
 use ark_ff::{Field, PrimeField};
-use ark_std::format;
+use ark_std::{format, One, Zero};
 use plonk_core::{constraint_system::StandardComposer, error::Error, prelude::Variable};
-use ark_std::{Zero, One};
 #[derive(Debug)]
 pub enum PoseidonError {
 	InvalidSboxSize(usize),
@@ -92,9 +91,10 @@ fn synthesize_exp3_sbox<E: PairingEngine, P: TEModelParameters<BaseField = E::Fr
 	input_var: &Variable,
 	composer: &mut StandardComposer<E, P>,
 ) -> Result<Variable, Error> {
-	let sqr =
-		composer.arithmetic_gate(|gate| gate.witness(*input_var, *input_var, None).mul(E::Fr::one()));
-	let cube = composer.arithmetic_gate(|gate| gate.witness(sqr, *input_var, None).mul(E::Fr::one()));
+	let sqr = composer
+		.arithmetic_gate(|gate| gate.witness(*input_var, *input_var, None).mul(E::Fr::one()));
+	let cube =
+		composer.arithmetic_gate(|gate| gate.witness(sqr, *input_var, None).mul(E::Fr::one()));
 	Ok(cube)
 }
 
@@ -103,8 +103,8 @@ fn synthesize_exp5_sbox<E: PairingEngine, P: TEModelParameters<BaseField = E::Fr
 	input_var: &Variable,
 	composer: &mut StandardComposer<E, P>,
 ) -> Result<Variable, Error> {
-	let sqr =
-		composer.arithmetic_gate(|gate| gate.witness(*input_var, *input_var, None).mul(E::Fr::one()));
+	let sqr = composer
+		.arithmetic_gate(|gate| gate.witness(*input_var, *input_var, None).mul(E::Fr::one()));
 	let fourth = composer.arithmetic_gate(|gate| gate.witness(sqr, sqr, None).mul(E::Fr::one()));
 	let fifth =
 		composer.arithmetic_gate(|gate| gate.witness(fourth, *input_var, None).mul(E::Fr::one()));
@@ -116,12 +116,14 @@ fn synthesize_exp17_sbox<E: PairingEngine, P: TEModelParameters<BaseField = E::F
 	input_var: &Variable,
 	composer: &mut StandardComposer<E, P>,
 ) -> Result<Variable, Error> {
-	let sqr =
-		composer.arithmetic_gate(|gate| gate.witness(*input_var, *input_var, None).mul(E::Fr::one()));
+	let sqr = composer
+		.arithmetic_gate(|gate| gate.witness(*input_var, *input_var, None).mul(E::Fr::one()));
 	let fourth = composer.arithmetic_gate(|gate| gate.witness(sqr, sqr, None).mul(E::Fr::one()));
-	let eigth = composer.arithmetic_gate(|gate| gate.witness(fourth, fourth, None).mul(E::Fr::one()));
-	let sixteenth = composer.arithmetic_gate(|gate| gate.witness(eigth, eigth, None).mul(E::Fr::one()));
-	let seventeenth =
-		composer.arithmetic_gate(|gate| gate.witness(sixteenth, *input_var, None).mul(E::Fr::one()));
+	let eigth =
+		composer.arithmetic_gate(|gate| gate.witness(fourth, fourth, None).mul(E::Fr::one()));
+	let sixteenth =
+		composer.arithmetic_gate(|gate| gate.witness(eigth, eigth, None).mul(E::Fr::one()));
+	let seventeenth = composer
+		.arithmetic_gate(|gate| gate.witness(sixteenth, *input_var, None).mul(E::Fr::one()));
 	Ok(seventeenth)
 }

--- a/arkworks-plonk-circuits/src/poseidon/sbox.rs
+++ b/arkworks-plonk-circuits/src/poseidon/sbox.rs
@@ -2,7 +2,7 @@ use ark_ec::{PairingEngine, TEModelParameters};
 use ark_ff::{Field, PrimeField};
 use ark_std::format;
 use plonk_core::{constraint_system::StandardComposer, error::Error, prelude::Variable};
-
+use ark_std::{Zero, One};
 #[derive(Debug)]
 pub enum PoseidonError {
 	InvalidSboxSize(usize),
@@ -62,66 +62,66 @@ impl PoseidonSbox {
 }
 
 pub trait SboxConstraints {
-	fn synthesize_sbox<F: PrimeField, P: TEModelParameters<BaseField = F>>(
+	fn synthesize_sbox<E: PairingEngine, P: TEModelParameters<BaseField = E::Fr>>(
 		&self,
 		input: &Variable,
-		composer: &mut StandardComposer<F, P>,
+		composer: &mut StandardComposer<E, P>,
 	) -> Result<Variable, Error>;
 }
 
 impl SboxConstraints for PoseidonSbox {
-	fn synthesize_sbox<F: PrimeField, P: TEModelParameters<BaseField = F>>(
+	fn synthesize_sbox<E: PairingEngine, P: TEModelParameters<BaseField = E::Fr>>(
 		&self,
 		input_var: &Variable,
-		composer: &mut StandardComposer<F, P>,
+		composer: &mut StandardComposer<E, P>,
 	) -> Result<Variable, Error> {
 		match self {
 			PoseidonSbox::Exponentiation(val) => match val {
-				3 => synthesize_exp3_sbox::<F, P>(input_var, composer),
-				5 => synthesize_exp5_sbox::<F, P>(input_var, composer),
-				17 => synthesize_exp17_sbox::<F, P>(input_var, composer),
-				_ => synthesize_exp3_sbox::<F, P>(input_var, composer),
+				3 => synthesize_exp3_sbox::<E, P>(input_var, composer),
+				5 => synthesize_exp5_sbox::<E, P>(input_var, composer),
+				17 => synthesize_exp17_sbox::<E, P>(input_var, composer),
+				_ => synthesize_exp3_sbox::<E, P>(input_var, composer),
 			},
-			_ => synthesize_exp3_sbox::<F, P>(input_var, composer),
+			_ => synthesize_exp3_sbox::<E, P>(input_var, composer),
 		}
 	}
 }
 
 // Allocate variables in circuit and enforce constraints when Sbox as cube
-fn synthesize_exp3_sbox<F: PrimeField, P: TEModelParameters<BaseField = F>>(
+fn synthesize_exp3_sbox<E: PairingEngine, P: TEModelParameters<BaseField = E::Fr>>(
 	input_var: &Variable,
-	composer: &mut StandardComposer<F, P>,
+	composer: &mut StandardComposer<E, P>,
 ) -> Result<Variable, Error> {
 	let sqr =
-		composer.arithmetic_gate(|gate| gate.witness(*input_var, *input_var, None).mul(F::one()));
-	let cube = composer.arithmetic_gate(|gate| gate.witness(sqr, *input_var, None).mul(F::one()));
+		composer.arithmetic_gate(|gate| gate.witness(*input_var, *input_var, None).mul(E::Fr::one()));
+	let cube = composer.arithmetic_gate(|gate| gate.witness(sqr, *input_var, None).mul(E::Fr::one()));
 	Ok(cube)
 }
 
 // Allocate variables in circuit and enforce constraints when Sbox as cube
-fn synthesize_exp5_sbox<F: PrimeField, P: TEModelParameters<BaseField = F>>(
+fn synthesize_exp5_sbox<E: PairingEngine, P: TEModelParameters<BaseField = E::Fr>>(
 	input_var: &Variable,
-	composer: &mut StandardComposer<F, P>,
+	composer: &mut StandardComposer<E, P>,
 ) -> Result<Variable, Error> {
 	let sqr =
-		composer.arithmetic_gate(|gate| gate.witness(*input_var, *input_var, None).mul(F::one()));
-	let fourth = composer.arithmetic_gate(|gate| gate.witness(sqr, sqr, None).mul(F::one()));
+		composer.arithmetic_gate(|gate| gate.witness(*input_var, *input_var, None).mul(E::Fr::one()));
+	let fourth = composer.arithmetic_gate(|gate| gate.witness(sqr, sqr, None).mul(E::Fr::one()));
 	let fifth =
-		composer.arithmetic_gate(|gate| gate.witness(fourth, *input_var, None).mul(F::one()));
+		composer.arithmetic_gate(|gate| gate.witness(fourth, *input_var, None).mul(E::Fr::one()));
 	Ok(fifth)
 }
 
 // Allocate variables in circuit and enforce constraints when Sbox as cube
-fn synthesize_exp17_sbox<F: PrimeField, P: TEModelParameters<BaseField = F>>(
+fn synthesize_exp17_sbox<E: PairingEngine, P: TEModelParameters<BaseField = E::Fr>>(
 	input_var: &Variable,
-	composer: &mut StandardComposer<F, P>,
+	composer: &mut StandardComposer<E, P>,
 ) -> Result<Variable, Error> {
 	let sqr =
-		composer.arithmetic_gate(|gate| gate.witness(*input_var, *input_var, None).mul(F::one()));
-	let fourth = composer.arithmetic_gate(|gate| gate.witness(sqr, sqr, None).mul(F::one()));
-	let eigth = composer.arithmetic_gate(|gate| gate.witness(fourth, fourth, None).mul(F::one()));
-	let sixteenth = composer.arithmetic_gate(|gate| gate.witness(eigth, eigth, None).mul(F::one()));
+		composer.arithmetic_gate(|gate| gate.witness(*input_var, *input_var, None).mul(E::Fr::one()));
+	let fourth = composer.arithmetic_gate(|gate| gate.witness(sqr, sqr, None).mul(E::Fr::one()));
+	let eigth = composer.arithmetic_gate(|gate| gate.witness(fourth, fourth, None).mul(E::Fr::one()));
+	let sixteenth = composer.arithmetic_gate(|gate| gate.witness(eigth, eigth, None).mul(E::Fr::one()));
 	let seventeenth =
-		composer.arithmetic_gate(|gate| gate.witness(sixteenth, *input_var, None).mul(F::one()));
+		composer.arithmetic_gate(|gate| gate.witness(sixteenth, *input_var, None).mul(E::Fr::one()));
 	Ok(seventeenth)
 }

--- a/arkworks-plonk-circuits/src/set_membership/mod.rs
+++ b/arkworks-plonk-circuits/src/set_membership/mod.rs
@@ -1,10 +1,7 @@
 use ark_ec::{models::TEModelParameters, PairingEngine};
 use ark_ff::PrimeField;
-use ark_std::vec::Vec;
-use plonk_core::{
-	constraint_system::StandardComposer, prelude::Variable,
-};
-use ark_std::{Zero, One};
+use ark_std::{vec::Vec, One, Zero};
+use plonk_core::{constraint_system::StandardComposer, prelude::Variable};
 
 /// A function whose output is 1 if `member` belongs to `set`
 /// and 0 otherwise.  Contraints are added to a StandardComposer
@@ -34,8 +31,8 @@ where
 	// Accumulate the product of all differences
 	let mut accumulator = composer.add_witness_to_circuit_description(E::Fr::one());
 	for diff in diffs {
-		accumulator =
-			composer.arithmetic_gate(|gate| gate.witness(accumulator, diff, None).mul(E::Fr::one()));
+		accumulator = composer
+			.arithmetic_gate(|gate| gate.witness(accumulator, diff, None).mul(E::Fr::one()));
 	}
 
 	composer.is_zero_with_output(accumulator)

--- a/arkworks-plonk-circuits/src/utils.rs
+++ b/arkworks-plonk-circuits/src/utils.rs
@@ -1,7 +1,11 @@
 use ark_ec::{models::TEModelParameters, PairingEngine};
 use ark_poly::polynomial::univariate::DensePolynomial;
-use ark_poly_commit::{kzg10::{KZG10, self}, sonic_pc::{SonicKZG10, self}, PolynomialCommitment};
-use ark_serialize::{CanonicalSerialize, CanonicalDeserialize};
+use ark_poly_commit::{
+	kzg10::{self, KZG10},
+	sonic_pc::{self, SonicKZG10},
+	PolynomialCommitment,
+};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{test_rng, vec::Vec};
 use plonk_core::{
 	prelude::*,
@@ -23,8 +27,7 @@ pub(crate) fn gadget_tester<
 	// Provers View
 	let (proof, public_inputs) = {
 		// Create a prover struct
-		let mut prover: Prover<E, P> =
-			Prover::new(b"demo");
+		let mut prover: Prover<E, P> = Prover::new(b"demo");
 
 		// Additionally key the transcript
 		prover.key_transcript(b"key", b"additional seed information");


### PR DESCRIPTION
- Adds the plonk anchor file with matching tests (taken from mixer)
- Updates all dependencies to use PairingEngine instead of PrimeField directly.