### PR TITLE
Plonk Anchor Vanchor

### DIFF
--- a/arkworks-circuits/src/circuit/vanchor.rs
+++ b/arkworks-circuits/src/circuit/vanchor.rs
@@ -1,6 +1,7 @@
 use crate::Vec;
 
 use ark_crypto_primitives::{crh::CRHGadget, CRH};
+use ark_ec::TEModelParameters;
 use ark_ff::fields::PrimeField;
 use ark_r1cs_std::{eq::EqGadget, fields::fp::FpVar, prelude::*};
 use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError};
@@ -20,6 +21,7 @@ use arkworks_gadgets::{
 	merkle_tree::{constraints::PathVar, Config as MerkleConfig, Path},
 	set::constraints::SetGadget,
 };
+use arkworks_utils::poseidon::PoseidonParameters;
 
 pub struct VAnchorCircuit<
 	F: PrimeField,

--- a/arkworks-gadgets/src/merkle_tree/simple_merkle.rs
+++ b/arkworks-gadgets/src/merkle_tree/simple_merkle.rs
@@ -167,6 +167,9 @@ impl<F: PrimeField, H: FieldHasher<F>, const N: usize> SparseMerkleTree<F, H, N>
 		Ok(smt)
 	}
 
+	/// This returns the DEFAULT root, i.e. root of an empty tree!
+	/// Not the root of the tree after some leaves have
+	/// been changed
 	pub fn root(&self) -> F {
 		self.tree
 			.get(&0)

--- a/arkworks-gadgets/src/merkle_tree/simple_merkle.rs
+++ b/arkworks-gadgets/src/merkle_tree/simple_merkle.rs
@@ -167,9 +167,7 @@ impl<F: PrimeField, H: FieldHasher<F>, const N: usize> SparseMerkleTree<F, H, N>
 		Ok(smt)
 	}
 
-	/// This returns the DEFAULT root, i.e. root of an empty tree!
-	/// Not the root of the tree after some leaves have
-	/// been changed
+	/// This returns the Merkle tree root
 	pub fn root(&self) -> F {
 		self.tree
 			.get(&0)

--- a/arkworks-gadgets/src/merkle_tree/simple_merkle.rs
+++ b/arkworks-gadgets/src/merkle_tree/simple_merkle.rs
@@ -30,7 +30,7 @@ impl ark_std::error::Error for MerkleError {}
 #[derive(Clone)]
 pub struct Path<F: PrimeField, H: FieldHasher<F>, const N: usize> {
 	pub path: [(F, F); N],
-	_marker: PhantomData<H>,
+	pub _marker: PhantomData<H>,
 }
 
 impl<F: PrimeField, H: FieldHasher<F>, const N: usize> Path<F, H, N> {

--- a/arkworks-plonk-circuits/Cargo.toml
+++ b/arkworks-plonk-circuits/Cargo.toml
@@ -16,6 +16,7 @@ ark-crypto-primitives = { version = "^0.3.0", features = ["r1cs"], default-featu
 ark-ff = { version = "^0.3.0", default-features = false }
 ark-std = { version = "^0.3.0", default-features = false }
 plonk-core = { version = "^0.8", git = "https://github.com/ZK-Garage/plonk", features = ["trace"], default-features = false }
+plonk-hashing = { git = "https://github.com/ZK-Garage/plonk.git", branch = "poseidon_hash" }
 
 ark-poly-commit = { version = "^0.3.0", default-features = false }
 ark-poly = { version = "^0.3.0", default-features = false }

--- a/arkworks-plonk-circuits/src/anchor/mod.rs
+++ b/arkworks-plonk-circuits/src/anchor/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-	mixer::add_public_input_variable, merkle_tree::PathGadget,
+	merkle_tree::PathGadget, mixer::add_public_input_variable,
 	poseidon::poseidon::FieldHasherGadget, set_membership::check_set_membership,
 };
 use ark_ec::{models::TEModelParameters, PairingEngine};
@@ -112,742 +112,749 @@ where
 	}
 }
 
-#[cfg(test)]
-mod test {
-	use super::AnchorCircuit;
-	use crate::{poseidon::poseidon::PoseidonGadget, utils::gadget_tester};
-	use ark_bn254::{Bn254, Fr as Bn254Fr};
-	use ark_ed_on_bn254::{EdwardsParameters as JubjubParameters, Fq};
-	use ark_ff::Field;
-	use ark_poly::polynomial::univariate::DensePolynomial;
-	use ark_poly_commit::{
-		kzg10::{self, UniversalParams},
-		sonic_pc::{self, SonicKZG10},
-		PolynomialCommitment,
-	};
-	use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-	use ark_std::test_rng;
-	use arkworks_gadgets::{
-		ark_std::UniformRand,
-		merkle_tree::simple_merkle::SparseMerkleTree,
-		poseidon::field_hasher::{FieldHasher, Poseidon},
-	};
-	use arkworks_utils::utils::common::{setup_params_x5_3, Curve};
-	use plonk_core::{
-		prelude::*,
-		proof_system::{Prover, Verifier},
-	};
-
-	type PoseidonBn254 = Poseidon<Fq>;
-
-	const BRIDGE_SIZE: usize = 2;
-
-	#[test]
-	fn should_verify_correct_anchor_plonk() {
-		let rng = &mut test_rng();
-		let curve = Curve::Bn254;
-
-		let params = setup_params_x5_3(curve);
-		let poseidon_native = PoseidonBn254 { params };
-
-		// Randomly generated secrets
-		let secret = Fq::rand(rng);
-		let nullifier = Fq::rand(rng);
-
-		// Public data
-		let chain_id = Fq::from(1u32);
-		let arbitrary_data = Fq::rand(rng);
-		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
-		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
-
-		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
-		// scalars, then add leaf_hash as the final leaf
-		const HEIGHT: usize = 6usize;
-		let last_index = 1 << (HEIGHT - 1) - 1;
-		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
-		for i in 0..last_index {
-			leaves[i] = Fq::rand(rng);
-		}
-		leaves[last_index] = leaf_hash;
-		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
-			&leaves,
-			&poseidon_native,
-			&[0u8; 32],
-		)
-		.unwrap();
-
-		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-		roots[0] = tree.root();
-
-		// Path
-		let path = tree.generate_membership_proof(last_index as u64);
-
-		// Create AnchorCircuit
-		let mut anchor =
-			AnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
-				chain_id,
-				secret,
-				nullifier,
-				nullifier_hash,
-				path,
-				roots,
-				arbitrary_data,
-				poseidon_native,
-			);
-
-		let res = gadget_tester::<Bn254, JubjubParameters, _>(&mut anchor, 1 << 17);
-		assert!(res.is_ok(), "{:?}", res.err().unwrap());
-	}
-
-	#[test]
-	fn should_fail_with_invalid_root_plonk() {
-		let rng = &mut test_rng();
-		let curve = Curve::Bn254;
-
-		let params = setup_params_x5_3(curve);
-		let poseidon_native = PoseidonBn254 { params };
-
-		// Randomly generated secrets
-		let secret = Fq::rand(rng);
-		let nullifier = Fq::rand(rng);
-
-		// Public data
-		let chain_id = Fq::from(1u32);
-		let arbitrary_data = Fq::rand(rng);
-		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
-		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
-
-		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
-		// scalars, then add leaf_hash as the final leaf
-		const HEIGHT: usize = 6usize;
-		let last_index = 1 << (HEIGHT - 1) - 1;
-		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
-		for i in 0..last_index {
-			leaves[i] = Fq::rand(rng);
-		}
-		leaves[last_index] = leaf_hash;
-		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
-			&leaves,
-			&poseidon_native,
-			&[0u8; 32],
-		)
-		.unwrap();
-		let mut root = tree.root();
-		let bad_root = root.double();
-		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-		roots[0] = bad_root;
-
-		// Path
-		let path = tree.generate_membership_proof(last_index as u64);
-
-		// Create AnchorCircuit
-		let mut anchor =
-			AnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
-				chain_id,
-				secret,
-				nullifier,
-				nullifier_hash,
-				path,
-				roots,
-				arbitrary_data,
-				poseidon_native,
-			);
-
-		// Fill a composer to extract the public_inputs
-		let mut composer = StandardComposer::<Bn254Fr, JubjubParameters>::new();
-		let _ = anchor.gadget(&mut composer);
-		let public_inputs = composer.construct_dense_pi_vec();
-
-		// Go through proof generation/verification
-		let u_params: UniversalParams<Bn254> =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
-		let proof = {
-			// Create a prover struct
-			let mut prover = Prover::<
-				Bn254,
-				JubjubParameters,
-				SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
-			>::new(b"anchor");
-			prover.key_transcript(b"key", b"additional seed information");
-			// Add gadgets
-			let _ = anchor.gadget(prover.mut_cs());
-			// Commit Key (being lazy with error)
-			let (ck, _) =
-				SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-					.unwrap();
-			// Preprocess circuit
-			let _ = prover.preprocess(&ck.powers());
-			// Compute Proof
-			prover.prove(&ck.powers()).unwrap()
-		};
-
-		// Verifier's view
-
-		// Create a Verifier object
-		let mut verifier = Verifier::new(b"anchor");
-		verifier.key_transcript(b"key", b"additional seed information");
-		// Add gadgets
-		let _ = anchor.gadget(verifier.mut_cs());
-		// Compute Commit and Verifier key
-		let (ck, vk) =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-				.unwrap();
-		// Preprocess circuit
-		verifier.preprocess(&ck.powers()).unwrap();
-
-		// Verify proof
-		let res = verifier.verify(&proof, &vk, &public_inputs).unwrap_err();
-		match res {
-			Error::ProofVerificationError => (),
-			err => panic!("Unexpected error: {:?}", err),
-		};
-	}
-
-	#[test]
-	fn should_fail_with_wrong_secret_plonk() {
-		let rng = &mut test_rng();
-		let curve = Curve::Bn254;
-
-		let params = setup_params_x5_3(curve);
-		let poseidon_native = PoseidonBn254 { params };
-
-		// Randomly generated secrets
-		let secret = Fq::rand(rng);
-		let nullifier = Fq::rand(rng);
-
-		// Public data
-		let chain_id = Fq::from(1u32);
-		let arbitrary_data = Fq::rand(rng);
-		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
-		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
-
-		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
-		// scalars, then add leaf_hash as the final leaf
-		const HEIGHT: usize = 6usize;
-		let last_index = 1 << (HEIGHT - 1) - 1;
-		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
-		for i in 0..last_index {
-			leaves[i] = Fq::rand(rng);
-		}
-		leaves[last_index] = leaf_hash;
-		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
-			&leaves,
-			&poseidon_native,
-			&[0u8; 32],
-		)
-		.unwrap();
-		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-		roots[0] = tree.root();
-		// Path
-		let path = tree.generate_membership_proof(last_index as u64);
-
-		// An incorrect secret value to use below
-		let bad_secret = secret.double();
-
-		// Create AnchorCircuit
-		let mut anchor =
-			AnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
-				chain_id,
-				bad_secret,
-				nullifier,
-				nullifier_hash,
-				path,
-				roots,
-				arbitrary_data,
-				poseidon_native,
-			);
-
-		// Fill a composer to extract the public_inputs
-		let mut composer = StandardComposer::<Bn254Fr, JubjubParameters>::new();
-		let _ = anchor.gadget(&mut composer);
-		let public_inputs = composer.construct_dense_pi_vec();
-
-		// Go through proof generation/verification
-		let u_params: UniversalParams<Bn254Fr> =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
-		let proof = {
-			// Create a prover struct
-			let mut prover = Prover::<
-				Bn254,
-				JubjubParameters,
-				SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
-			>::new(b"anchor");
-			prover.key_transcript(b"key", b"additional seed information");
-			// Add gadgets
-			let _ = anchor.gadget(prover.mut_cs());
-			// Commit Key (being lazy with error)
-			let (ck, _) =
-				SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-					.unwrap();
-			// Preprocess circuit
-			let _ = prover.preprocess(&ck.powers());
-			// Compute Proof
-			prover.prove(&ck.powers()).unwrap()
-		};
-
-		// Verifier's view
-
-		// Create a Verifier object
-		let mut verifier = Verifier::new(b"anchor");
-		verifier.key_transcript(b"key", b"additional seed information");
-		// Add gadgets
-		let _ = anchor.gadget(verifier.mut_cs());
-		// Compute Commit and Verifier key
-		let (ck, vk) =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-				.unwrap();
-		// Preprocess circuit
-		verifier.preprocess(&ck.powers()).unwrap();
-
-		// Verify proof
-		let mut vk_bytes = Vec::new();
-		sonic_pc::VerifierKey::<Bn254Fr>::serialize(&vk, &mut vk_bytes).unwrap();
-		let kzg_vk = kzg10::VerifierKey::<Bn254Fr>::deserialize(&vk_bytes[..]).unwrap();
-		let res = verifier
-			.verify(&proof, &kzg_vk, &public_inputs)
-			.unwrap_err();
-		match res {
-			Error::ProofVerificationError => (),
-			err => panic!("Unexpected error: {:?}", err),
-		};
-	}
-
-	#[test]
-	fn should_fail_with_wrong_nullifier_plonk() {
-		let rng = &mut test_rng();
-		let curve = Curve::Bn254;
-
-		let params = setup_params_x5_3(curve);
-		let poseidon_native = PoseidonBn254 { params };
-
-		// Randomly generated secrets
-		let secret = Fq::rand(rng);
-		let nullifier = Fq::rand(rng);
-
-		// Public data
-		let chain_id = Fq::from(1u32);
-		let arbitrary_data = Fq::rand(rng);
-		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
-		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
-
-		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
-		// scalars, then add leaf_hash as the final leaf
-		const HEIGHT: usize = 6usize;
-		let last_index = 1 << (HEIGHT - 1) - 1;
-		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
-		for i in 0..last_index {
-			leaves[i] = Fq::rand(rng);
-		}
-		leaves[last_index] = leaf_hash;
-		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
-			&leaves,
-			&poseidon_native,
-			&[0u8; 32],
-		)
-		.unwrap();
-		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-		roots[0] = tree.root();
-
-		// Path
-		let path = tree.generate_membership_proof(last_index as u64);
-
-		// An incorrect secret value to use below
-		let bad_nullifier = nullifier.double();
-
-		// Create AnchorCircuit
-		let mut anchor =
-			AnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
-				chain_id,
-				secret,
-				bad_nullifier,
-				nullifier_hash,
-				path,
-				roots,
-				arbitrary_data,
-				poseidon_native,
-			);
-
-		// Fill a composer to extract the public_inputs
-		let mut composer = StandardComposer::<Bn254Fr, JubjubParameters>::new();
-		let _ = anchor.gadget(&mut composer);
-		let public_inputs = composer.construct_dense_pi_vec();
-
-		// Go through proof generation/verification
-		let u_params: UniversalParams<Bn254Fr> =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
-		let proof = {
-			// Create a prover struct
-			let mut prover = Prover::<
-				Bn254,
-				JubjubParameters,
-				SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
-			>::new(b"anchor");
-			prover.key_transcript(b"key", b"additional seed information");
-			// Add gadgets
-			let _ = anchor.gadget(prover.mut_cs());
-			// Commit Key (being lazy with error)
-			let (ck, _) =
-				SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-					.unwrap();
-			// Preprocess circuit
-			let _ = prover.preprocess(&ck.powers());
-			// Compute Proof
-			prover.prove(&ck.powers()).unwrap()
-		};
-
-		// Verifier's view
-
-		// Create a Verifier object
-		let mut verifier = Verifier::new(b"anchor");
-		verifier.key_transcript(b"key", b"additional seed information");
-		// Add gadgets
-		let _ = anchor.gadget(verifier.mut_cs());
-		// Compute Commit and Verifier key
-		let (ck, vk) =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-				.unwrap();
-		// Preprocess circuit
-		verifier.preprocess(&ck.powers()).unwrap();
-
-		// Verify proof
-		let mut vk_bytes = Vec::new();
-		sonic_pc::VerifierKey::<Bn254Fr>::serialize(&vk, &mut vk_bytes).unwrap();
-		let kzg_vk = kzg10::VerifierKey::<Bn254Fr>::deserialize(&vk_bytes[..]).unwrap();
-		let res = verifier
-			.verify(&proof, &kzg_vk, &public_inputs)
-			.unwrap_err();
-		match res {
-			Error::ProofVerificationError => (),
-			err => panic!("Unexpected error: {:?}", err),
-		};
-	}
-
-	#[test]
-	fn should_fail_with_wrong_path_plonk() {
-		let rng = &mut test_rng();
-		let curve = Curve::Bn254;
-
-		let params = setup_params_x5_3(curve);
-		let poseidon_native = PoseidonBn254 { params };
-
-		// Randomly generated secrets
-		let secret = Fq::rand(rng);
-		let nullifier = Fq::rand(rng);
-
-		// Public data
-		let chain_id = Fq::from(1u32);
-		let arbitrary_data = Fq::rand(rng);
-		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
-		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
-
-		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
-		// scalars, then add leaf_hash as the final leaf
-		const HEIGHT: usize = 6usize;
-		let last_index = 1 << (HEIGHT - 1) - 1;
-		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
-		for i in 0..last_index {
-			leaves[i] = Fq::rand(rng);
-		}
-		leaves[last_index] = leaf_hash;
-		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
-			&leaves,
-			&poseidon_native,
-			&[0u8; 32],
-		)
-		.unwrap();
-		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-		roots[0] = tree.root();
-
-		// An incorrect path to use below
-		let bad_path = tree.generate_membership_proof((last_index as u64) - 1);
-
-		// Create AnchorCircuit
-		let mut anchor =
-			AnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
-				chain_id,
-				secret,
-				nullifier,
-				nullifier_hash,
-				bad_path,
-				roots,
-				arbitrary_data,
-				poseidon_native,
-			);
-
-		// Fill a composer to extract the public_inputs
-		let mut composer = StandardComposer::<Bn254Fr, JubjubParameters>::new();
-		let _ = anchor.gadget(&mut composer);
-		let public_inputs = composer.construct_dense_pi_vec();
-
-		// Go through proof generation/verification
-		let u_params: UniversalParams<Bn254Fr> =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
-		let proof = {
-			// Create a prover struct
-			let mut prover = Prover::<
-				Bn254,
-				JubjubParameters,
-				SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
-			>::new(b"anchor");
-			prover.key_transcript(b"key", b"additional seed information");
-			// Add gadgets
-			let _ = anchor.gadget(prover.mut_cs());
-			// Commit Key (being lazy with error)
-			let (ck, _) =
-				SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-					.unwrap();
-			// Preprocess circuit
-			let _ = prover.preprocess(&ck.powers());
-			// Compute Proof
-			prover.prove(&ck.powers()).unwrap()
-		};
-
-		// Verifier's view
-
-		// Create a Verifier object
-		let mut verifier = Verifier::new(b"anchor");
-		verifier.key_transcript(b"key", b"additional seed information");
-		// Add gadgets
-		let _ = anchor.gadget(verifier.mut_cs());
-		// Compute Commit and Verifier key
-		let (ck, vk) =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-				.unwrap();
-		// Preprocess circuit
-		verifier.preprocess(&ck.powers()).unwrap();
-
-		// Verify proof
-		let mut vk_bytes = Vec::new();
-		sonic_pc::VerifierKey::<Bn254Fr>::serialize(&vk, &mut vk_bytes).unwrap();
-		let kzg_vk = kzg10::VerifierKey::<Bn254Fr>::deserialize(&vk_bytes[..]).unwrap();
-		let res = verifier
-			.verify(&proof, &kzg_vk, &public_inputs)
-			.unwrap_err();
-		match res {
-			Error::ProofVerificationError => (),
-			err => panic!("Unexpected error: {:?}", err),
-		};
-	}
-
-	#[test]
-	fn should_fail_with_wrong_nullifier_hash_plonk() {
-		let rng = &mut test_rng();
-		let curve = Curve::Bn254;
-
-		let params = setup_params_x5_3(curve);
-		let poseidon_native = PoseidonBn254 { params };
-
-		// Randomly generated secrets
-		let secret = Fq::rand(rng);
-		let nullifier = Fq::rand(rng);
-
-		// Public data
-		let chain_id = Fq::from(1u32);
-		let arbitrary_data = Fq::rand(rng);
-		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
-		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
-
-		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
-		// scalars, then add leaf_hash as the final leaf
-		const HEIGHT: usize = 6usize;
-		let last_index = 1 << (HEIGHT - 1) - 1;
-		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
-		for i in 0..last_index {
-			leaves[i] = Fq::rand(rng);
-		}
-		leaves[last_index] = leaf_hash;
-		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
-			&leaves,
-			&poseidon_native,
-			&[0u8; 32],
-		)
-		.unwrap();
-		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-		roots[0] = tree.root();
-
-		// Path
-		let path = tree.generate_membership_proof(last_index as u64);
-
-		// Incorrect nullifier hash to use below
-		let bad_nullifier_hash = nullifier_hash.double();
-
-		// Create AnchorCircuit
-		let mut anchor =
-			AnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
-				chain_id,
-				secret,
-				nullifier,
-				bad_nullifier_hash,
-				path,
-				roots,
-				arbitrary_data,
-				poseidon_native,
-			);
-
-		// Fill a composer to extract the public_inputs
-		let mut composer = StandardComposer::<Bn254Fr, JubjubParameters>::new();
-		let _ = anchor.gadget(&mut composer);
-		let public_inputs = composer.construct_dense_pi_vec();
-
-		// Go through proof generation/verification
-		let u_params: UniversalParams<Bn254Fr> =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
-		let proof = {
-			// Create a prover struct
-			let mut prover = Prover::<
-				Bn254,
-				JubjubParameters,
-				SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
-			>::new(b"anchor");
-			prover.key_transcript(b"key", b"additional seed information");
-			// Add gadgets
-			let _ = anchor.gadget(prover.mut_cs());
-			// Commit Key (being lazy with error)
-			let (ck, _) =
-				SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-					.unwrap();
-			// Preprocess circuit
-			let _ = prover.preprocess(&ck.powers());
-			// Compute Proof
-			prover.prove(&ck.powers()).unwrap()
-		};
-
-		// Verifier's view
-
-		// Create a Verifier object
-		let mut verifier = Verifier::new(b"anchor");
-		verifier.key_transcript(b"key", b"additional seed information");
-		// Add gadgets
-		let _ = anchor.gadget(verifier.mut_cs());
-		// Compute Commit and Verifier key
-		let (ck, vk) =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-				.unwrap();
-		// Preprocess circuit
-		verifier.preprocess(&ck.powers()).unwrap();
-
-		// Verify proof
-		let mut vk_bytes = Vec::new();
-		sonic_pc::VerifierKey::<Bn254Fr>::serialize(&vk, &mut vk_bytes).unwrap();
-		let kzg_vk = kzg10::VerifierKey::<Bn254Fr>::deserialize(&vk_bytes[..]).unwrap();
-		let res = verifier
-			.verify(&proof, &kzg_vk, &public_inputs)
-			.unwrap_err();
-		match res {
-			Error::ProofVerificationError => (),
-			err => panic!("Unexpected error: {:?}", err),
-		};
-	}
-
-	#[test]
-	fn should_fail_with_wrong_arbitrary_data_plonk() {
-		let rng = &mut test_rng();
-		let curve = Curve::Bn254;
-
-		let params = setup_params_x5_3(curve);
-		let poseidon_native = PoseidonBn254 { params };
-
-		// Randomly generated secrets
-		let secret = Fq::rand(rng);
-		let nullifier = Fq::rand(rng);
-
-		// Public data
-		let chain_id = Fq::from(1u32);
-		let arbitrary_data = Fq::rand(rng);
-		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
-		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
-
-		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
-		// scalars, then add leaf_hash as the final leaf
-		const HEIGHT: usize = 6usize;
-		let last_index = 1 << (HEIGHT - 1) - 1;
-		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
-		for i in 0..last_index {
-			leaves[i] = Fq::rand(rng);
-		}
-		leaves[last_index] = leaf_hash;
-		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
-			&leaves,
-			&poseidon_native,
-			&[0u8; 32],
-		)
-		.unwrap();
-		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-		roots[0] = tree.root();
-
-		// Path
-		let path = tree.generate_membership_proof(last_index as u64);
-
-		// Create AnchorCircuit
-		let mut anchor =
-			AnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
-				chain_id,
-				secret,
-				nullifier,
-				nullifier_hash,
-				path,
-				roots,
-				arbitrary_data,
-				poseidon_native,
-			);
-
-		// Fill a composer to extract the public_inputs
-		let mut composer = StandardComposer::<Bn254Fr, JubjubParameters>::new();
-		let _ = anchor.gadget(&mut composer);
-		let mut public_inputs = composer.construct_dense_pi_vec();
-
-		// Go through proof generation/verification
-		let u_params: UniversalParams<Bn254Fr> =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
-		let proof = {
-			// Create a prover struct
-			let mut prover = Prover::<
-				Bn254,
-				JubjubParameters,
-				SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
-			>::new(b"anchor");
-			prover.key_transcript(b"key", b"additional seed information");
-			// Add gadgets
-			let _ = anchor.gadget(prover.mut_cs());
-			// Commit Key (being lazy with error)
-			let (ck, _) =
-				SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-					.unwrap();
-			// Preprocess circuit
-			let _ = prover.preprocess(&ck.powers());
-			// Compute Proof
-			prover.prove(&ck.powers()).unwrap()
-		};
-
-		// Verifier's view
-
-		// Create a Verifier object
-		let mut verifier = Verifier::new(b"anchor");
-		verifier.key_transcript(b"key", b"additional seed information");
-		// Add gadgets
-		let _ = anchor.gadget(verifier.mut_cs());
-		// Compute Commit and Verifier key
-		let (ck, vk) =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-				.unwrap();
-		// Preprocess circuit
-		verifier.preprocess(&ck.powers()).unwrap();
-
-		// The arbitrary data is stored at index 5 of the public input vector:
-		assert_eq!(arbitrary_data, public_inputs[7]);
-		// Modify the arbitrary data so that prover/verifier disagree
-		public_inputs[5].double_in_place();
-
-		// Verify proof
-		let mut vk_bytes = Vec::new();
-		sonic_pc::VerifierKey::<Bn254Fr>::serialize(&vk, &mut vk_bytes).unwrap();
-		let kzg_vk = kzg10::VerifierKey::<Bn254Fr>::deserialize(&vk_bytes[..]).unwrap();
-		let res = verifier
-			.verify(&proof, &kzg_vk, &public_inputs)
-			.unwrap_err();
-		match res {
-			Error::ProofVerificationError => (),
-			err => panic!("Unexpected error: {:?}", err),
-		};
-	}
-}
+// #[cfg(test)]
+// mod test {
+// 	use super::AnchorCircuit;
+// 	use crate::{poseidon::poseidon::PoseidonGadget, utils::gadget_tester};
+// 	use ark_bn254::{Bn254, Fr as Bn254Fr};
+// 	use ark_ed_on_bn254::{EdwardsParameters as JubjubParameters, Fq};
+// 	use ark_ff::Field;
+// 	use ark_poly::polynomial::univariate::DensePolynomial;
+// 	use ark_poly_commit::{
+// 		kzg10::{self, UniversalParams},
+// 		sonic_pc::{self, SonicKZG10},
+// 		PolynomialCommitment,
+// 	};
+// 	use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+// 	use ark_std::test_rng;
+// 	use arkworks_gadgets::{
+// 		ark_std::UniformRand,
+// 		merkle_tree::simple_merkle::SparseMerkleTree,
+// 		poseidon::field_hasher::{FieldHasher, Poseidon},
+// 	};
+// 	use arkworks_utils::utils::common::{setup_params_x5_3, Curve};
+// 	use plonk_core::{
+// 		prelude::*,
+// 		proof_system::{Prover, Verifier},
+// 	};
+
+// 	type PoseidonBn254 = Poseidon<Fq>;
+
+// 	const BRIDGE_SIZE: usize = 2;
+
+// 	#[test]
+// 	fn should_verify_correct_anchor_plonk() {
+// 		let rng = &mut test_rng();
+// 		let curve = Curve::Bn254;
+
+// 		let params = setup_params_x5_3(curve);
+// 		let poseidon_native = PoseidonBn254 { params };
+
+// 		// Randomly generated secrets
+// 		let secret = Fq::rand(rng);
+// 		let nullifier = Fq::rand(rng);
+
+// 		// Public data
+// 		let chain_id = Fq::from(1u32);
+// 		let arbitrary_data = Fq::rand(rng);
+// 		let nullifier_hash = poseidon_native.hash_two(&nullifier,
+// &nullifier).unwrap(); 		let leaf_hash = poseidon_native.hash_two(&secret,
+// &nullifier).unwrap();
+
+// 		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
+// 		// scalars, then add leaf_hash as the final leaf
+// 		const HEIGHT: usize = 6usize;
+// 		let last_index = 1 << (HEIGHT - 1) - 1;
+// 		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
+// 		for i in 0..last_index {
+// 			leaves[i] = Fq::rand(rng);
+// 		}
+// 		leaves[last_index] = leaf_hash;
+// 		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
+// 			&leaves,
+// 			&poseidon_native,
+// 			&[0u8; 32],
+// 		)
+// 		.unwrap();
+
+// 		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+// 		roots[0] = tree.root();
+
+// 		// Path
+// 		let path = tree.generate_membership_proof(last_index as u64);
+
+// 		// Create AnchorCircuit
+// 		let mut anchor =
+// 			AnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT,
+// BRIDGE_SIZE>::new( 				chain_id,
+// 				secret,
+// 				nullifier,
+// 				nullifier_hash,
+// 				path,
+// 				roots,
+// 				arbitrary_data,
+// 				poseidon_native,
+// 			);
+
+// 		let res = gadget_tester::<Bn254, JubjubParameters, _>(&mut anchor, 1 << 17);
+// 		assert!(res.is_ok(), "{:?}", res.err().unwrap());
+// 	}
+
+// 	#[test]
+// 	fn should_fail_with_invalid_root_plonk() {
+// 		let rng = &mut test_rng();
+// 		let curve = Curve::Bn254;
+
+// 		let params = setup_params_x5_3(curve);
+// 		let poseidon_native = PoseidonBn254 { params };
+
+// 		// Randomly generated secrets
+// 		let secret = Fq::rand(rng);
+// 		let nullifier = Fq::rand(rng);
+
+// 		// Public data
+// 		let chain_id = Fq::from(1u32);
+// 		let arbitrary_data = Fq::rand(rng);
+// 		let nullifier_hash = poseidon_native.hash_two(&nullifier,
+// &nullifier).unwrap(); 		let leaf_hash = poseidon_native.hash_two(&secret,
+// &nullifier).unwrap();
+
+// 		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
+// 		// scalars, then add leaf_hash as the final leaf
+// 		const HEIGHT: usize = 6usize;
+// 		let last_index = 1 << (HEIGHT - 1) - 1;
+// 		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
+// 		for i in 0..last_index {
+// 			leaves[i] = Fq::rand(rng);
+// 		}
+// 		leaves[last_index] = leaf_hash;
+// 		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
+// 			&leaves,
+// 			&poseidon_native,
+// 			&[0u8; 32],
+// 		)
+// 		.unwrap();
+// 		let mut root = tree.root();
+// 		let bad_root = root.double();
+// 		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+// 		roots[0] = bad_root;
+
+// 		// Path
+// 		let path = tree.generate_membership_proof(last_index as u64);
+
+// 		// Create AnchorCircuit
+// 		let mut anchor =
+// 			AnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT,
+// BRIDGE_SIZE>::new( 				chain_id,
+// 				secret,
+// 				nullifier,
+// 				nullifier_hash,
+// 				path,
+// 				roots,
+// 				arbitrary_data,
+// 				poseidon_native,
+// 			);
+
+// 		// Fill a composer to extract the public_inputs
+// 		let mut composer = StandardComposer::<Bn254Fr, JubjubParameters>::new();
+// 		let _ = anchor.gadget(&mut composer);
+// 		let public_inputs = composer.construct_dense_pi_vec();
+
+// 		// Go through proof generation/verification
+// 		let u_params: UniversalParams<Bn254> =
+// 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None,
+// rng).unwrap(); 		let proof = {
+// 			// Create a prover struct
+// 			let mut prover = Prover::<
+// 				Bn254,
+// 				JubjubParameters,
+// 				SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
+// 			>::new(b"anchor");
+// 			prover.key_transcript(b"key", b"additional seed information");
+// 			// Add gadgets
+// 			let _ = anchor.gadget(prover.mut_cs());
+// 			// Commit Key (being lazy with error)
+// 			let (ck, _) =
+// 				SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0,
+// None) 					.unwrap();
+// 			// Preprocess circuit
+// 			let _ = prover.preprocess(&ck.powers());
+// 			// Compute Proof
+// 			prover.prove(&ck.powers()).unwrap()
+// 		};
+
+// 		// Verifier's view
+
+// 		// Create a Verifier object
+// 		let mut verifier = Verifier::new(b"anchor");
+// 		verifier.key_transcript(b"key", b"additional seed information");
+// 		// Add gadgets
+// 		let _ = anchor.gadget(verifier.mut_cs());
+// 		// Compute Commit and Verifier key
+// 		let (ck, vk) =
+// 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0,
+// None) 				.unwrap();
+// 		// Preprocess circuit
+// 		verifier.preprocess(&ck.powers()).unwrap();
+
+// 		// Verify proof
+// 		let res = verifier.verify(&proof, &vk, &public_inputs).unwrap_err();
+// 		match res {
+// 			Error::ProofVerificationError => (),
+// 			err => panic!("Unexpected error: {:?}", err),
+// 		};
+// 	}
+
+// 	#[test]
+// 	fn should_fail_with_wrong_secret_plonk() {
+// 		let rng = &mut test_rng();
+// 		let curve = Curve::Bn254;
+
+// 		let params = setup_params_x5_3(curve);
+// 		let poseidon_native = PoseidonBn254 { params };
+
+// 		// Randomly generated secrets
+// 		let secret = Fq::rand(rng);
+// 		let nullifier = Fq::rand(rng);
+
+// 		// Public data
+// 		let chain_id = Fq::from(1u32);
+// 		let arbitrary_data = Fq::rand(rng);
+// 		let nullifier_hash = poseidon_native.hash_two(&nullifier,
+// &nullifier).unwrap(); 		let leaf_hash = poseidon_native.hash_two(&secret,
+// &nullifier).unwrap();
+
+// 		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
+// 		// scalars, then add leaf_hash as the final leaf
+// 		const HEIGHT: usize = 6usize;
+// 		let last_index = 1 << (HEIGHT - 1) - 1;
+// 		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
+// 		for i in 0..last_index {
+// 			leaves[i] = Fq::rand(rng);
+// 		}
+// 		leaves[last_index] = leaf_hash;
+// 		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
+// 			&leaves,
+// 			&poseidon_native,
+// 			&[0u8; 32],
+// 		)
+// 		.unwrap();
+// 		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+// 		roots[0] = tree.root();
+// 		// Path
+// 		let path = tree.generate_membership_proof(last_index as u64);
+
+// 		// An incorrect secret value to use below
+// 		let bad_secret = secret.double();
+
+// 		// Create AnchorCircuit
+// 		let mut anchor =
+// 			AnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT,
+// BRIDGE_SIZE>::new( 				chain_id,
+// 				bad_secret,
+// 				nullifier,
+// 				nullifier_hash,
+// 				path,
+// 				roots,
+// 				arbitrary_data,
+// 				poseidon_native,
+// 			);
+
+// 		// Fill a composer to extract the public_inputs
+// 		let mut composer = StandardComposer::<Bn254Fr, JubjubParameters>::new();
+// 		let _ = anchor.gadget(&mut composer);
+// 		let public_inputs = composer.construct_dense_pi_vec();
+
+// 		// Go through proof generation/verification
+// 		let u_params: UniversalParams<Bn254Fr> =
+// 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None,
+// rng).unwrap(); 		let proof = {
+// 			// Create a prover struct
+// 			let mut prover = Prover::<
+// 				Bn254,
+// 				JubjubParameters,
+// 				SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
+// 			>::new(b"anchor");
+// 			prover.key_transcript(b"key", b"additional seed information");
+// 			// Add gadgets
+// 			let _ = anchor.gadget(prover.mut_cs());
+// 			// Commit Key (being lazy with error)
+// 			let (ck, _) =
+// 				SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0,
+// None) 					.unwrap();
+// 			// Preprocess circuit
+// 			let _ = prover.preprocess(&ck.powers());
+// 			// Compute Proof
+// 			prover.prove(&ck.powers()).unwrap()
+// 		};
+
+// 		// Verifier's view
+
+// 		// Create a Verifier object
+// 		let mut verifier = Verifier::new(b"anchor");
+// 		verifier.key_transcript(b"key", b"additional seed information");
+// 		// Add gadgets
+// 		let _ = anchor.gadget(verifier.mut_cs());
+// 		// Compute Commit and Verifier key
+// 		let (ck, vk) =
+// 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0,
+// None) 				.unwrap();
+// 		// Preprocess circuit
+// 		verifier.preprocess(&ck.powers()).unwrap();
+
+// 		// Verify proof
+// 		let mut vk_bytes = Vec::new();
+// 		sonic_pc::VerifierKey::<Bn254Fr>::serialize(&vk, &mut vk_bytes).unwrap();
+// 		let kzg_vk =
+// kzg10::VerifierKey::<Bn254Fr>::deserialize(&vk_bytes[..]).unwrap(); 		let res =
+// verifier 			.verify(&proof, &kzg_vk, &public_inputs)
+// 			.unwrap_err();
+// 		match res {
+// 			Error::ProofVerificationError => (),
+// 			err => panic!("Unexpected error: {:?}", err),
+// 		};
+// 	}
+
+// 	#[test]
+// 	fn should_fail_with_wrong_nullifier_plonk() {
+// 		let rng = &mut test_rng();
+// 		let curve = Curve::Bn254;
+
+// 		let params = setup_params_x5_3(curve);
+// 		let poseidon_native = PoseidonBn254 { params };
+
+// 		// Randomly generated secrets
+// 		let secret = Fq::rand(rng);
+// 		let nullifier = Fq::rand(rng);
+
+// 		// Public data
+// 		let chain_id = Fq::from(1u32);
+// 		let arbitrary_data = Fq::rand(rng);
+// 		let nullifier_hash = poseidon_native.hash_two(&nullifier,
+// &nullifier).unwrap(); 		let leaf_hash = poseidon_native.hash_two(&secret,
+// &nullifier).unwrap();
+
+// 		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
+// 		// scalars, then add leaf_hash as the final leaf
+// 		const HEIGHT: usize = 6usize;
+// 		let last_index = 1 << (HEIGHT - 1) - 1;
+// 		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
+// 		for i in 0..last_index {
+// 			leaves[i] = Fq::rand(rng);
+// 		}
+// 		leaves[last_index] = leaf_hash;
+// 		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
+// 			&leaves,
+// 			&poseidon_native,
+// 			&[0u8; 32],
+// 		)
+// 		.unwrap();
+// 		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+// 		roots[0] = tree.root();
+
+// 		// Path
+// 		let path = tree.generate_membership_proof(last_index as u64);
+
+// 		// An incorrect secret value to use below
+// 		let bad_nullifier = nullifier.double();
+
+// 		// Create AnchorCircuit
+// 		let mut anchor =
+// 			AnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT,
+// BRIDGE_SIZE>::new( 				chain_id,
+// 				secret,
+// 				bad_nullifier,
+// 				nullifier_hash,
+// 				path,
+// 				roots,
+// 				arbitrary_data,
+// 				poseidon_native,
+// 			);
+
+// 		// Fill a composer to extract the public_inputs
+// 		let mut composer = StandardComposer::<Bn254Fr, JubjubParameters>::new();
+// 		let _ = anchor.gadget(&mut composer);
+// 		let public_inputs = composer.construct_dense_pi_vec();
+
+// 		// Go through proof generation/verification
+// 		let u_params: UniversalParams<Bn254Fr> =
+// 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None,
+// rng).unwrap(); 		let proof = {
+// 			// Create a prover struct
+// 			let mut prover = Prover::<
+// 				Bn254,
+// 				JubjubParameters,
+// 				SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
+// 			>::new(b"anchor");
+// 			prover.key_transcript(b"key", b"additional seed information");
+// 			// Add gadgets
+// 			let _ = anchor.gadget(prover.mut_cs());
+// 			// Commit Key (being lazy with error)
+// 			let (ck, _) =
+// 				SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0,
+// None) 					.unwrap();
+// 			// Preprocess circuit
+// 			let _ = prover.preprocess(&ck.powers());
+// 			// Compute Proof
+// 			prover.prove(&ck.powers()).unwrap()
+// 		};
+
+// 		// Verifier's view
+
+// 		// Create a Verifier object
+// 		let mut verifier = Verifier::new(b"anchor");
+// 		verifier.key_transcript(b"key", b"additional seed information");
+// 		// Add gadgets
+// 		let _ = anchor.gadget(verifier.mut_cs());
+// 		// Compute Commit and Verifier key
+// 		let (ck, vk) =
+// 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0,
+// None) 				.unwrap();
+// 		// Preprocess circuit
+// 		verifier.preprocess(&ck.powers()).unwrap();
+
+// 		// Verify proof
+// 		let mut vk_bytes = Vec::new();
+// 		sonic_pc::VerifierKey::<Bn254Fr>::serialize(&vk, &mut vk_bytes).unwrap();
+// 		let kzg_vk =
+// kzg10::VerifierKey::<Bn254Fr>::deserialize(&vk_bytes[..]).unwrap(); 		let res =
+// verifier 			.verify(&proof, &kzg_vk, &public_inputs)
+// 			.unwrap_err();
+// 		match res {
+// 			Error::ProofVerificationError => (),
+// 			err => panic!("Unexpected error: {:?}", err),
+// 		};
+// 	}
+
+// 	#[test]
+// 	fn should_fail_with_wrong_path_plonk() {
+// 		let rng = &mut test_rng();
+// 		let curve = Curve::Bn254;
+
+// 		let params = setup_params_x5_3(curve);
+// 		let poseidon_native = PoseidonBn254 { params };
+
+// 		// Randomly generated secrets
+// 		let secret = Fq::rand(rng);
+// 		let nullifier = Fq::rand(rng);
+
+// 		// Public data
+// 		let chain_id = Fq::from(1u32);
+// 		let arbitrary_data = Fq::rand(rng);
+// 		let nullifier_hash = poseidon_native.hash_two(&nullifier,
+// &nullifier).unwrap(); 		let leaf_hash = poseidon_native.hash_two(&secret,
+// &nullifier).unwrap();
+
+// 		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
+// 		// scalars, then add leaf_hash as the final leaf
+// 		const HEIGHT: usize = 6usize;
+// 		let last_index = 1 << (HEIGHT - 1) - 1;
+// 		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
+// 		for i in 0..last_index {
+// 			leaves[i] = Fq::rand(rng);
+// 		}
+// 		leaves[last_index] = leaf_hash;
+// 		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
+// 			&leaves,
+// 			&poseidon_native,
+// 			&[0u8; 32],
+// 		)
+// 		.unwrap();
+// 		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+// 		roots[0] = tree.root();
+
+// 		// An incorrect path to use below
+// 		let bad_path = tree.generate_membership_proof((last_index as u64) - 1);
+
+// 		// Create AnchorCircuit
+// 		let mut anchor =
+// 			AnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT,
+// BRIDGE_SIZE>::new( 				chain_id,
+// 				secret,
+// 				nullifier,
+// 				nullifier_hash,
+// 				bad_path,
+// 				roots,
+// 				arbitrary_data,
+// 				poseidon_native,
+// 			);
+
+// 		// Fill a composer to extract the public_inputs
+// 		let mut composer = StandardComposer::<Bn254Fr, JubjubParameters>::new();
+// 		let _ = anchor.gadget(&mut composer);
+// 		let public_inputs = composer.construct_dense_pi_vec();
+
+// 		// Go through proof generation/verification
+// 		let u_params: UniversalParams<Bn254Fr> =
+// 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None,
+// rng).unwrap(); 		let proof = {
+// 			// Create a prover struct
+// 			let mut prover = Prover::<
+// 				Bn254,
+// 				JubjubParameters,
+// 				SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
+// 			>::new(b"anchor");
+// 			prover.key_transcript(b"key", b"additional seed information");
+// 			// Add gadgets
+// 			let _ = anchor.gadget(prover.mut_cs());
+// 			// Commit Key (being lazy with error)
+// 			let (ck, _) =
+// 				SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0,
+// None) 					.unwrap();
+// 			// Preprocess circuit
+// 			let _ = prover.preprocess(&ck.powers());
+// 			// Compute Proof
+// 			prover.prove(&ck.powers()).unwrap()
+// 		};
+
+// 		// Verifier's view
+
+// 		// Create a Verifier object
+// 		let mut verifier = Verifier::new(b"anchor");
+// 		verifier.key_transcript(b"key", b"additional seed information");
+// 		// Add gadgets
+// 		let _ = anchor.gadget(verifier.mut_cs());
+// 		// Compute Commit and Verifier key
+// 		let (ck, vk) =
+// 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0,
+// None) 				.unwrap();
+// 		// Preprocess circuit
+// 		verifier.preprocess(&ck.powers()).unwrap();
+
+// 		// Verify proof
+// 		let mut vk_bytes = Vec::new();
+// 		sonic_pc::VerifierKey::<Bn254Fr>::serialize(&vk, &mut vk_bytes).unwrap();
+// 		let kzg_vk =
+// kzg10::VerifierKey::<Bn254Fr>::deserialize(&vk_bytes[..]).unwrap(); 		let res =
+// verifier 			.verify(&proof, &kzg_vk, &public_inputs)
+// 			.unwrap_err();
+// 		match res {
+// 			Error::ProofVerificationError => (),
+// 			err => panic!("Unexpected error: {:?}", err),
+// 		};
+// 	}
+
+// 	#[test]
+// 	fn should_fail_with_wrong_nullifier_hash_plonk() {
+// 		let rng = &mut test_rng();
+// 		let curve = Curve::Bn254;
+
+// 		let params = setup_params_x5_3(curve);
+// 		let poseidon_native = PoseidonBn254 { params };
+
+// 		// Randomly generated secrets
+// 		let secret = Fq::rand(rng);
+// 		let nullifier = Fq::rand(rng);
+
+// 		// Public data
+// 		let chain_id = Fq::from(1u32);
+// 		let arbitrary_data = Fq::rand(rng);
+// 		let nullifier_hash = poseidon_native.hash_two(&nullifier,
+// &nullifier).unwrap(); 		let leaf_hash = poseidon_native.hash_two(&secret,
+// &nullifier).unwrap();
+
+// 		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
+// 		// scalars, then add leaf_hash as the final leaf
+// 		const HEIGHT: usize = 6usize;
+// 		let last_index = 1 << (HEIGHT - 1) - 1;
+// 		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
+// 		for i in 0..last_index {
+// 			leaves[i] = Fq::rand(rng);
+// 		}
+// 		leaves[last_index] = leaf_hash;
+// 		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
+// 			&leaves,
+// 			&poseidon_native,
+// 			&[0u8; 32],
+// 		)
+// 		.unwrap();
+// 		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+// 		roots[0] = tree.root();
+
+// 		// Path
+// 		let path = tree.generate_membership_proof(last_index as u64);
+
+// 		// Incorrect nullifier hash to use below
+// 		let bad_nullifier_hash = nullifier_hash.double();
+
+// 		// Create AnchorCircuit
+// 		let mut anchor =
+// 			AnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT,
+// BRIDGE_SIZE>::new( 				chain_id,
+// 				secret,
+// 				nullifier,
+// 				bad_nullifier_hash,
+// 				path,
+// 				roots,
+// 				arbitrary_data,
+// 				poseidon_native,
+// 			);
+
+// 		// Fill a composer to extract the public_inputs
+// 		let mut composer = StandardComposer::<Bn254Fr, JubjubParameters>::new();
+// 		let _ = anchor.gadget(&mut composer);
+// 		let public_inputs = composer.construct_dense_pi_vec();
+
+// 		// Go through proof generation/verification
+// 		let u_params: UniversalParams<Bn254Fr> =
+// 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None,
+// rng).unwrap(); 		let proof = {
+// 			// Create a prover struct
+// 			let mut prover = Prover::<
+// 				Bn254,
+// 				JubjubParameters,
+// 				SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
+// 			>::new(b"anchor");
+// 			prover.key_transcript(b"key", b"additional seed information");
+// 			// Add gadgets
+// 			let _ = anchor.gadget(prover.mut_cs());
+// 			// Commit Key (being lazy with error)
+// 			let (ck, _) =
+// 				SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0,
+// None) 					.unwrap();
+// 			// Preprocess circuit
+// 			let _ = prover.preprocess(&ck.powers());
+// 			// Compute Proof
+// 			prover.prove(&ck.powers()).unwrap()
+// 		};
+
+// 		// Verifier's view
+
+// 		// Create a Verifier object
+// 		let mut verifier = Verifier::new(b"anchor");
+// 		verifier.key_transcript(b"key", b"additional seed information");
+// 		// Add gadgets
+// 		let _ = anchor.gadget(verifier.mut_cs());
+// 		// Compute Commit and Verifier key
+// 		let (ck, vk) =
+// 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0,
+// None) 				.unwrap();
+// 		// Preprocess circuit
+// 		verifier.preprocess(&ck.powers()).unwrap();
+
+// 		// Verify proof
+// 		let mut vk_bytes = Vec::new();
+// 		sonic_pc::VerifierKey::<Bn254Fr>::serialize(&vk, &mut vk_bytes).unwrap();
+// 		let kzg_vk =
+// kzg10::VerifierKey::<Bn254Fr>::deserialize(&vk_bytes[..]).unwrap(); 		let res =
+// verifier 			.verify(&proof, &kzg_vk, &public_inputs)
+// 			.unwrap_err();
+// 		match res {
+// 			Error::ProofVerificationError => (),
+// 			err => panic!("Unexpected error: {:?}", err),
+// 		};
+// 	}
+
+// 	#[test]
+// 	fn should_fail_with_wrong_arbitrary_data_plonk() {
+// 		let rng = &mut test_rng();
+// 		let curve = Curve::Bn254;
+
+// 		let params = setup_params_x5_3(curve);
+// 		let poseidon_native = PoseidonBn254 { params };
+
+// 		// Randomly generated secrets
+// 		let secret = Fq::rand(rng);
+// 		let nullifier = Fq::rand(rng);
+
+// 		// Public data
+// 		let chain_id = Fq::from(1u32);
+// 		let arbitrary_data = Fq::rand(rng);
+// 		let nullifier_hash = poseidon_native.hash_two(&nullifier,
+// &nullifier).unwrap(); 		let leaf_hash = poseidon_native.hash_two(&secret,
+// &nullifier).unwrap();
+
+// 		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
+// 		// scalars, then add leaf_hash as the final leaf
+// 		const HEIGHT: usize = 6usize;
+// 		let last_index = 1 << (HEIGHT - 1) - 1;
+// 		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
+// 		for i in 0..last_index {
+// 			leaves[i] = Fq::rand(rng);
+// 		}
+// 		leaves[last_index] = leaf_hash;
+// 		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
+// 			&leaves,
+// 			&poseidon_native,
+// 			&[0u8; 32],
+// 		)
+// 		.unwrap();
+// 		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+// 		roots[0] = tree.root();
+
+// 		// Path
+// 		let path = tree.generate_membership_proof(last_index as u64);
+
+// 		// Create AnchorCircuit
+// 		let mut anchor =
+// 			AnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT,
+// BRIDGE_SIZE>::new( 				chain_id,
+// 				secret,
+// 				nullifier,
+// 				nullifier_hash,
+// 				path,
+// 				roots,
+// 				arbitrary_data,
+// 				poseidon_native,
+// 			);
+
+// 		// Fill a composer to extract the public_inputs
+// 		let mut composer = StandardComposer::<Bn254Fr, JubjubParameters>::new();
+// 		let _ = anchor.gadget(&mut composer);
+// 		let mut public_inputs = composer.construct_dense_pi_vec();
+
+// 		// Go through proof generation/verification
+// 		let u_params: UniversalParams<Bn254Fr> =
+// 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None,
+// rng).unwrap(); 		let proof = {
+// 			// Create a prover struct
+// 			let mut prover = Prover::<
+// 				Bn254,
+// 				JubjubParameters,
+// 				SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
+// 			>::new(b"anchor");
+// 			prover.key_transcript(b"key", b"additional seed information");
+// 			// Add gadgets
+// 			let _ = anchor.gadget(prover.mut_cs());
+// 			// Commit Key (being lazy with error)
+// 			let (ck, _) =
+// 				SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0,
+// None) 					.unwrap();
+// 			// Preprocess circuit
+// 			let _ = prover.preprocess(&ck.powers());
+// 			// Compute Proof
+// 			prover.prove(&ck.powers()).unwrap()
+// 		};
+
+// 		// Verifier's view
+
+// 		// Create a Verifier object
+// 		let mut verifier = Verifier::new(b"anchor");
+// 		verifier.key_transcript(b"key", b"additional seed information");
+// 		// Add gadgets
+// 		let _ = anchor.gadget(verifier.mut_cs());
+// 		// Compute Commit and Verifier key
+// 		let (ck, vk) =
+// 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0,
+// None) 				.unwrap();
+// 		// Preprocess circuit
+// 		verifier.preprocess(&ck.powers()).unwrap();
+
+// 		// The arbitrary data is stored at index 5 of the public input vector:
+// 		assert_eq!(arbitrary_data, public_inputs[7]);
+// 		// Modify the arbitrary data so that prover/verifier disagree
+// 		public_inputs[5].double_in_place();
+
+// 		// Verify proof
+// 		let mut vk_bytes = Vec::new();
+// 		sonic_pc::VerifierKey::<Bn254Fr>::serialize(&vk, &mut vk_bytes).unwrap();
+// 		let kzg_vk =
+// kzg10::VerifierKey::<Bn254Fr>::deserialize(&vk_bytes[..]).unwrap(); 		let res =
+// verifier 			.verify(&proof, &kzg_vk, &public_inputs)
+// 			.unwrap_err();
+// 		match res {
+// 			Error::ProofVerificationError => (),
+// 			err => panic!("Unexpected error: {:?}", err),
+// 		};
+// 	}
+// }

--- a/arkworks-plonk-circuits/src/anchor/mod.rs
+++ b/arkworks-plonk-circuits/src/anchor/mod.rs
@@ -24,7 +24,8 @@ pub struct AnchorCircuit<
 	path: Path<F, HG::Native, N>,
 	roots: [F; M],
 	arbitrary_data: F,
-	hasher: HG::Native,
+	hasher_two: HG::Native,   // Arity 2 hasher
+	hasher_three: HG::Native, // Arity 3 hasher
 }
 
 impl<F, P, HG, const N: usize, const M: usize> AnchorCircuit<F, P, HG, N, M>
@@ -41,7 +42,8 @@ where
 		path: Path<F, HG::Native, N>,
 		roots: [F; M],
 		arbitrary_data: F,
-		hasher: HG::Native,
+		hasher_two: HG::Native,
+		hasher_three: HG::Native,
 	) -> Self {
 		Self {
 			chain_id,
@@ -51,7 +53,8 @@ where
 			path,
 			roots,
 			arbitrary_data,
-			hasher,
+			hasher_two,
+			hasher_three,
 		}
 	}
 }
@@ -72,30 +75,29 @@ where
 		let path_gadget = PathGadget::<F, P, HG, N>::from_native(composer, self.path.clone());
 
 		// Public Inputs
-		let chain_id = add_public_input_variable(composer, self.chain_id); // Unused -- Why ?
+		let chain_id = add_public_input_variable(composer, self.chain_id);
 		let nullifier_hash = add_public_input_variable(composer, self.nullifier_hash);
-		let roots = self
-			.roots
-			.iter()
-			.map(|root| add_public_input_variable(composer, *root))
-			.collect::<Vec<Variable>>(); // Unused -- Why ?
 		let arbitrary_data = add_public_input_variable(composer, self.arbitrary_data);
 
-		// Create the hasher_gadget from native
-		let hasher_gadget: HG =
-			FieldHasherGadget::<F, P>::from_native(composer, self.hasher.clone());
+		// Create the hasher gadgets from native
+		let hasher_gadget_two: HG =
+			FieldHasherGadget::<F, P>::from_native(composer, self.hasher_two.clone());
+		let hasher_gadget_three: HG =
+			FieldHasherGadget::<F, P>::from_native(composer, self.hasher_three.clone());
 
 		// Preimage proof of nullifier
-		let res_nullifier = hasher_gadget.hash_two(composer, &nullifier, &nullifier)?;
+		let res_nullifier = hasher_gadget_two.hash_two(composer, &nullifier, &nullifier)?;
 		// TODO: (This has 1 more gate than skipping the nullifier_hash variable and
 		// putting this straight in to a poly_gate)
 		composer.assert_equal(res_nullifier, nullifier_hash);
 
 		// Preimage proof of leaf hash
-		let res_leaf = hasher_gadget.hash_two(composer, &secret, &nullifier)?;
+		// leaf should be hash of [chain_id, secret, nullifier]
+		let res_leaf = hasher_gadget_three.hash(composer, &[chain_id, secret, nullifier])?;
 
 		// Proof of Merkle tree set membership
-		let calculated_root = path_gadget.calculate_root(composer, &res_leaf, &hasher_gadget)?;
+		let calculated_root =
+			path_gadget.calculate_root(composer, &res_leaf, &hasher_gadget_two)?;
 		let result = check_set_membership(composer, &self.roots.to_vec(), calculated_root);
 		let one = composer.add_witness_to_circuit_description(F::one());
 		composer.assert_equal(result, one);
@@ -109,7 +111,7 @@ where
 	}
 
 	fn padded_circuit_size(&self) -> usize {
-		1 << 16
+		1 << 19
 	}
 }
 
@@ -127,7 +129,7 @@ mod test {
 		merkle_tree::simple_merkle::SparseMerkleTree,
 		poseidon::field_hasher::{FieldHasher, Poseidon},
 	};
-	use arkworks_utils::utils::common::{setup_params_x5_3, Curve};
+	use arkworks_utils::utils::common::{setup_params_x5_3, setup_params_x5_4, Curve};
 	use plonk_core::prelude::*;
 
 	type Bn254Fr = <Bn254 as PairingEngine>::Fr;
@@ -139,8 +141,16 @@ mod test {
 		let rng = &mut test_rng();
 		let curve = Curve::Bn254;
 
-		let params = setup_params_x5_3(curve);
-		let poseidon_native = PoseidonBn254 { params };
+		// These poseidon hashers are named after their WIDTH, not ARITY.
+		// So `poseidon_native_three` is for hashing 2 elements together, not 3.
+		let params_three = setup_params_x5_3(curve);
+		let params_four = setup_params_x5_4(curve);
+		let poseidon_native_three = PoseidonBn254 {
+			params: params_three,
+		};
+		let poseidon_native_four = PoseidonBn254 {
+			params: params_four,
+		};
 
 		// Randomly generated secrets
 		let secret = Fq::rand(rng);
@@ -149,8 +159,12 @@ mod test {
 		// Public data
 		let chain_id = Fq::from(1u32);
 		let arbitrary_data = Fq::rand(rng);
-		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
-		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
+		let nullifier_hash = poseidon_native_three
+			.hash_two(&nullifier, &nullifier)
+			.unwrap();
+		let leaf_hash = poseidon_native_four
+			.hash(&[chain_id, secret, nullifier])
+			.unwrap();
 
 		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
 		// scalars, then add leaf_hash as the final leaf
@@ -163,16 +177,18 @@ mod test {
 		leaves[last_index] = leaf_hash;
 		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
 			&leaves,
-			&poseidon_native,
+			&poseidon_native_three,
 			&[0u8; 32],
 		)
 		.unwrap();
 
-		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-		roots[0] = tree.root();
-
 		// Path
 		let path = tree.generate_membership_proof(last_index as u64);
+
+		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+		roots[0] = path
+			.calculate_root(&leaf_hash, &poseidon_native_three)
+			.unwrap();
 
 		// Create AnchorCircuit
 		let mut anchor =
@@ -184,7 +200,8 @@ mod test {
 				path,
 				roots,
 				arbitrary_data,
-				poseidon_native,
+				poseidon_native_three,
+				poseidon_native_four,
 			);
 
 		let res = prove_then_verify::<Bn254, JubjubParameters, _>(
@@ -200,79 +217,20 @@ mod test {
 	}
 
 	#[test]
-	fn should_fail_with_invalid_root_plonk() {
-		let rng = &mut test_rng();
-		let curve = Curve::Bn254;
-
-		let params = setup_params_x5_3(curve);
-		let poseidon_native = PoseidonBn254 { params };
-
-		// Randomly generated secrets
-		let secret = Fq::rand(rng);
-		let nullifier = Fq::rand(rng);
-
-		// Public data
-		let chain_id = Fq::from(1u32);
-		let arbitrary_data = Fq::rand(rng);
-		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
-		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
-
-		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
-		// scalars, then add leaf_hash as the final leaf
-		const HEIGHT: usize = 6usize;
-		let last_index = 1 << (HEIGHT - 1) - 1;
-		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
-		for i in 0..last_index {
-			leaves[i] = Fq::rand(rng);
-		}
-		leaves[last_index] = leaf_hash;
-		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
-			&leaves,
-			&poseidon_native,
-			&[0u8; 32],
-		)
-		.unwrap();
-
-		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-		// Use a bad root for this failure test
-		roots[0] = tree.root().double();
-
-		// Path
-		let path = tree.generate_membership_proof(last_index as u64);
-
-		// Create AnchorCircuit
-		let mut anchor =
-			AnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
-				chain_id,
-				secret,
-				nullifier,
-				nullifier_hash,
-				path,
-				roots,
-				arbitrary_data,
-				poseidon_native,
-			);
-
-		let res = prove_then_verify::<Bn254, JubjubParameters, _>(
-			&mut |c| anchor.gadget(c),
-			1 << 17,
-			None,
-		);
-		// Assert that verification failed
-		match res {
-			Err(Error::ProofVerificationError) => (),
-			Err(err) => panic!("Unexpected error: {:?}", err),
-			Ok(()) => panic!("Proof was successfully verified when error was expected"),
-		};
-	}
-
-	#[test]
 	fn should_fail_with_invalid_secret_plonk() {
 		let rng = &mut test_rng();
 		let curve = Curve::Bn254;
 
-		let params = setup_params_x5_3(curve);
-		let poseidon_native = PoseidonBn254 { params };
+		// These poseidon hashers are named after their WIDTH, not ARITY.
+		// So `poseidon_native_three` is for hashing 2 elements together, not 3.
+		let params_three = setup_params_x5_3(curve);
+		let params_four = setup_params_x5_4(curve);
+		let poseidon_native_three = PoseidonBn254 {
+			params: params_three,
+		};
+		let poseidon_native_four = PoseidonBn254 {
+			params: params_four,
+		};
 
 		// Randomly generated secrets
 		let secret = Fq::rand(rng);
@@ -281,8 +239,12 @@ mod test {
 		// Public data
 		let chain_id = Fq::from(1u32);
 		let arbitrary_data = Fq::rand(rng);
-		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
-		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
+		let nullifier_hash = poseidon_native_three
+			.hash_two(&nullifier, &nullifier)
+			.unwrap();
+		let leaf_hash = poseidon_native_four
+			.hash(&[chain_id, secret, nullifier])
+			.unwrap();
 
 		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
 		// scalars, then add leaf_hash as the final leaf
@@ -295,16 +257,18 @@ mod test {
 		leaves[last_index] = leaf_hash;
 		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
 			&leaves,
-			&poseidon_native,
+			&poseidon_native_three,
 			&[0u8; 32],
 		)
 		.unwrap();
 
-		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-		roots[0] = tree.root();
-
 		// Path
 		let path = tree.generate_membership_proof(last_index as u64);
+
+		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+		roots[0] = path
+			.calculate_root(&leaf_hash, &poseidon_native_three)
+			.unwrap();
 
 		// Use the wrong secret:
 		let bad_secret = secret.double();
@@ -319,7 +283,8 @@ mod test {
 				path,
 				roots,
 				arbitrary_data,
-				poseidon_native,
+				poseidon_native_three,
+				poseidon_native_four,
 			);
 
 		let res = prove_then_verify::<Bn254, JubjubParameters, _>(
@@ -340,8 +305,16 @@ mod test {
 		let rng = &mut test_rng();
 		let curve = Curve::Bn254;
 
-		let params = setup_params_x5_3(curve);
-		let poseidon_native = PoseidonBn254 { params };
+		// These poseidon hashers are named after their WIDTH, not ARITY.
+		// So `poseidon_native_three` is for hashing 2 elements together, not 3.
+		let params_three = setup_params_x5_3(curve);
+		let params_four = setup_params_x5_4(curve);
+		let poseidon_native_three = PoseidonBn254 {
+			params: params_three,
+		};
+		let poseidon_native_four = PoseidonBn254 {
+			params: params_four,
+		};
 
 		// Randomly generated secrets
 		let secret = Fq::rand(rng);
@@ -350,8 +323,12 @@ mod test {
 		// Public data
 		let chain_id = Fq::from(1u32);
 		let arbitrary_data = Fq::rand(rng);
-		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
-		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
+		let nullifier_hash = poseidon_native_three
+			.hash_two(&nullifier, &nullifier)
+			.unwrap();
+		let leaf_hash = poseidon_native_four
+			.hash(&[chain_id, secret, nullifier])
+			.unwrap();
 
 		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
 		// scalars, then add leaf_hash as the final leaf
@@ -364,18 +341,20 @@ mod test {
 		leaves[last_index] = leaf_hash;
 		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
 			&leaves,
-			&poseidon_native,
+			&poseidon_native_three,
 			&[0u8; 32],
 		)
 		.unwrap();
 
-		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-		roots[0] = tree.root();
-
 		// Path
 		let path = tree.generate_membership_proof(last_index as u64);
 
-		// Use bad nullifier
+		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+		roots[0] = path
+			.calculate_root(&leaf_hash, &poseidon_native_three)
+			.unwrap();
+
+		// Use the wrong nullifier:
 		let bad_nullifier = nullifier.double();
 
 		// Create AnchorCircuit
@@ -388,7 +367,8 @@ mod test {
 				path,
 				roots,
 				arbitrary_data,
-				poseidon_native,
+				poseidon_native_three,
+				poseidon_native_four,
 			);
 
 		let res = prove_then_verify::<Bn254, JubjubParameters, _>(
@@ -409,8 +389,16 @@ mod test {
 		let rng = &mut test_rng();
 		let curve = Curve::Bn254;
 
-		let params = setup_params_x5_3(curve);
-		let poseidon_native = PoseidonBn254 { params };
+		// These poseidon hashers are named after their WIDTH, not ARITY.
+		// So `poseidon_native_three` is for hashing 2 elements together, not 3.
+		let params_three = setup_params_x5_3(curve);
+		let params_four = setup_params_x5_4(curve);
+		let poseidon_native_three = PoseidonBn254 {
+			params: params_three,
+		};
+		let poseidon_native_four = PoseidonBn254 {
+			params: params_four,
+		};
 
 		// Randomly generated secrets
 		let secret = Fq::rand(rng);
@@ -419,8 +407,12 @@ mod test {
 		// Public data
 		let chain_id = Fq::from(1u32);
 		let arbitrary_data = Fq::rand(rng);
-		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
-		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
+		let nullifier_hash = poseidon_native_three
+			.hash_two(&nullifier, &nullifier)
+			.unwrap();
+		let leaf_hash = poseidon_native_four
+			.hash(&[chain_id, secret, nullifier])
+			.unwrap();
 
 		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
 		// scalars, then add leaf_hash as the final leaf
@@ -433,13 +425,18 @@ mod test {
 		leaves[last_index] = leaf_hash;
 		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
 			&leaves,
-			&poseidon_native,
+			&poseidon_native_three,
 			&[0u8; 32],
 		)
 		.unwrap();
 
+		// Path
+		let path = tree.generate_membership_proof(last_index as u64);
+
 		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-		roots[0] = tree.root();
+		roots[0] = path
+			.calculate_root(&leaf_hash, &poseidon_native_three)
+			.unwrap();
 
 		// Use an invalid path
 		let bad_path = tree.generate_membership_proof((last_index - 1) as u64);
@@ -454,7 +451,8 @@ mod test {
 				bad_path,
 				roots,
 				arbitrary_data,
-				poseidon_native,
+				poseidon_native_three,
+				poseidon_native_four,
 			);
 
 		let res = prove_then_verify::<Bn254, JubjubParameters, _>(
@@ -471,12 +469,20 @@ mod test {
 	}
 
 	#[test]
-	fn should_fail_with_invalid_nullifier_hash_plonk() {
+	fn should_fail_with_invalid_root_plonk() {
 		let rng = &mut test_rng();
 		let curve = Curve::Bn254;
 
-		let params = setup_params_x5_3(curve);
-		let poseidon_native = PoseidonBn254 { params };
+		// These poseidon hashers are named after their WIDTH, not ARITY.
+		// So `poseidon_native_three` is for hashing 2 elements together, not 3.
+		let params_three = setup_params_x5_3(curve);
+		let params_four = setup_params_x5_4(curve);
+		let poseidon_native_three = PoseidonBn254 {
+			params: params_three,
+		};
+		let poseidon_native_four = PoseidonBn254 {
+			params: params_four,
+		};
 
 		// Randomly generated secrets
 		let secret = Fq::rand(rng);
@@ -485,8 +491,12 @@ mod test {
 		// Public data
 		let chain_id = Fq::from(1u32);
 		let arbitrary_data = Fq::rand(rng);
-		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
-		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
+		let nullifier_hash = poseidon_native_three
+			.hash_two(&nullifier, &nullifier)
+			.unwrap();
+		let leaf_hash = poseidon_native_four
+			.hash(&[chain_id, secret, nullifier])
+			.unwrap();
 
 		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
 		// scalars, then add leaf_hash as the final leaf
@@ -499,16 +509,18 @@ mod test {
 		leaves[last_index] = leaf_hash;
 		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
 			&leaves,
-			&poseidon_native,
+			&poseidon_native_three,
 			&[0u8; 32],
 		)
 		.unwrap();
 
-		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-		roots[0] = tree.root();
-
 		// Path
 		let path = tree.generate_membership_proof(last_index as u64);
+
+		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+		roots[0] = path
+			.calculate_root(&leaf_hash, &poseidon_native_three)
+			.unwrap();
 
 		// Create AnchorCircuit
 		let mut anchor =
@@ -520,24 +532,115 @@ mod test {
 				path,
 				roots,
 				arbitrary_data,
-				poseidon_native,
+				poseidon_native_three,
+				poseidon_native_four,
 			);
 
 		// Prover and verifier disagree on public inputs:
 		// The order of public inputs is [chain_id, nullifier_hash, roots,
-		// arbitrary_data ] (Uncomment the following block to verify that)
+		// arbitrary_data, -roots ] (Uncomment the following block to verify that)
 		// let mut composer = StandardComposer::<Fq, JubjubParameters>::new();
 		// let _ = anchor.gadget(&mut composer);
 		// println!("The public input positions are {:?}", composer.pi_positions());
 		// let prover_pi = composer.construct_dense_pi_vec();
-		// assert_eq!([prover_pi[3], prover_pi[4], prover_pi[5], prover_pi[6],
-		// prover_pi[7], prover_pi[13125], prover_pi[13126]], 	[chain_id, nullifier_hash,
-		// roots[0], roots[1], arbitrary_data, -roots[0], -roots[1]]);
+		// assert_eq!(
+		// 	[prover_pi[3], prover_pi[4], prover_pi[5], prover_pi[14355],
+		// prover_pi[14356]], 	[chain_id, nullifier_hash, arbitrary_data, -roots[0],
+		// -roots[1]]);
+		let verifier_pi = vec![
+			chain_id,
+			nullifier_hash,
+			arbitrary_data,
+			-roots[0].double(), // Verifier has different root set
+			-roots[1],
+		];
+		let res = prove_then_verify::<Bn254, JubjubParameters, _>(
+			&mut |c| anchor.gadget(c),
+			1 << 17,
+			Some(verifier_pi),
+		);
+		// // Assert that verification failed
+		match res {
+			Err(Error::ProofVerificationError) => (),
+			Err(err) => panic!("Unexpected error: {:?}", err),
+			Ok(()) => panic!("Proof was successfully verified when error wasexpected"),
+		};
+	}
+
+	#[test]
+	fn should_fail_with_invalid_nullifier_hash_plonk() {
+		let rng = &mut test_rng();
+		let curve = Curve::Bn254;
+
+		// These poseidon hashers are named after their WIDTH, not ARITY.
+		// So `poseidon_native_three` is for hashing 2 elements together, not 3.
+		let params_three = setup_params_x5_3(curve);
+		let params_four = setup_params_x5_4(curve);
+		let poseidon_native_three = PoseidonBn254 {
+			params: params_three,
+		};
+		let poseidon_native_four = PoseidonBn254 {
+			params: params_four,
+		};
+
+		// Randomly generated secrets
+		let secret = Fq::rand(rng);
+		let nullifier = Fq::rand(rng);
+
+		// Public data
+		let chain_id = Fq::from(1u32);
+		let arbitrary_data = Fq::rand(rng);
+		let nullifier_hash = poseidon_native_three
+			.hash_two(&nullifier, &nullifier)
+			.unwrap();
+		let leaf_hash = poseidon_native_four
+			.hash(&[chain_id, secret, nullifier])
+			.unwrap();
+
+		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
+		// scalars, then add leaf_hash as the final leaf
+		const HEIGHT: usize = 6usize;
+		let last_index = 1 << (HEIGHT - 1) - 1;
+		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
+		for i in 0..last_index {
+			leaves[i] = Fq::rand(rng);
+		}
+		leaves[last_index] = leaf_hash;
+		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
+			&leaves,
+			&poseidon_native_three,
+			&[0u8; 32],
+		)
+		.unwrap();
+
+		// Path
+		let path = tree.generate_membership_proof(last_index as u64);
+
+		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+		roots[0] = path
+			.calculate_root(&leaf_hash, &poseidon_native_three)
+			.unwrap();
+
+		// Create AnchorCircuit
+		let mut anchor =
+			AnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
+				chain_id,
+				secret,
+				nullifier,
+				nullifier_hash,
+				path,
+				roots,
+				arbitrary_data,
+				poseidon_native_three,
+				poseidon_native_four,
+			);
+
+		// Prover and verifier disagree on public inputs:
+		// The order of public inputs is [chain_id, nullifier_hash, roots,
+		// arbitrary_data, -roots ]
 		let verifier_pi = vec![
 			chain_id,
 			nullifier_hash.double(), // Verifier has different nullifier hash
-			roots[0],
-			roots[1],
 			arbitrary_data,
 			-roots[0],
 			-roots[1],
@@ -551,7 +654,7 @@ mod test {
 		match res {
 			Err(Error::ProofVerificationError) => (),
 			Err(err) => panic!("Unexpected error: {:?}", err),
-			Ok(()) => panic!("Proof was successfully verified when error was expected"),
+			Ok(()) => panic!("Proof was successfully verified when error wasexpected"),
 		};
 	}
 
@@ -560,8 +663,16 @@ mod test {
 		let rng = &mut test_rng();
 		let curve = Curve::Bn254;
 
-		let params = setup_params_x5_3(curve);
-		let poseidon_native = PoseidonBn254 { params };
+		// These poseidon hashers are named after their WIDTH, not ARITY.
+		// So `poseidon_native_three` is for hashing 2 elements together, not 3.
+		let params_three = setup_params_x5_3(curve);
+		let params_four = setup_params_x5_4(curve);
+		let poseidon_native_three = PoseidonBn254 {
+			params: params_three,
+		};
+		let poseidon_native_four = PoseidonBn254 {
+			params: params_four,
+		};
 
 		// Randomly generated secrets
 		let secret = Fq::rand(rng);
@@ -570,8 +681,12 @@ mod test {
 		// Public data
 		let chain_id = Fq::from(1u32);
 		let arbitrary_data = Fq::rand(rng);
-		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
-		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
+		let nullifier_hash = poseidon_native_three
+			.hash_two(&nullifier, &nullifier)
+			.unwrap();
+		let leaf_hash = poseidon_native_four
+			.hash(&[chain_id, secret, nullifier])
+			.unwrap();
 
 		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
 		// scalars, then add leaf_hash as the final leaf
@@ -584,16 +699,18 @@ mod test {
 		leaves[last_index] = leaf_hash;
 		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
 			&leaves,
-			&poseidon_native,
+			&poseidon_native_three,
 			&[0u8; 32],
 		)
 		.unwrap();
 
-		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-		roots[0] = tree.root();
-
 		// Path
 		let path = tree.generate_membership_proof(last_index as u64);
+
+		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+		roots[0] = path
+			.calculate_root(&leaf_hash, &poseidon_native_three)
+			.unwrap();
 
 		// Create AnchorCircuit
 		let mut anchor =
@@ -605,24 +722,16 @@ mod test {
 				path,
 				roots,
 				arbitrary_data,
-				poseidon_native,
+				poseidon_native_three,
+				poseidon_native_four,
 			);
 
 		// Prover and verifier disagree on public inputs:
 		// The order of public inputs is [chain_id, nullifier_hash, roots,
-		// arbitrary_data ] (Uncomment the following block to verify that)
-		// let mut composer = StandardComposer::<Fq, JubjubParameters>::new();
-		// let _ = anchor.gadget(&mut composer);
-		// println!("The public input positions are {:?}", composer.pi_positions());
-		// let prover_pi = composer.construct_dense_pi_vec();
-		// assert_eq!([prover_pi[3], prover_pi[4], prover_pi[5], prover_pi[6],
-		// prover_pi[7], prover_pi[13125], prover_pi[13126]], 	[chain_id, nullifier_hash,
-		// roots[0], roots[1], arbitrary_data, -roots[0], -roots[1]]);
+		// arbitrary_data, -roots ]
 		let verifier_pi = vec![
 			chain_id,
 			nullifier_hash,
-			roots[0],
-			roots[1],
 			arbitrary_data.double(), // Verifier has different arbitrary data
 			-roots[0],
 			-roots[1],
@@ -636,7 +745,98 @@ mod test {
 		match res {
 			Err(Error::ProofVerificationError) => (),
 			Err(err) => panic!("Unexpected error: {:?}", err),
-			Ok(()) => panic!("Proof was successfully verified when error was expected"),
+			Ok(()) => panic!("Proof was successfully verified when error wasexpected"),
+		};
+	}
+
+	#[test]
+	fn should_fail_with_invalid_chain_id_plonk() {
+		let rng = &mut test_rng();
+		let curve = Curve::Bn254;
+
+		// These poseidon hashers are named after their WIDTH, not ARITY.
+		// So `poseidon_native_three` is for hashing 2 elements together, not 3.
+		let params_three = setup_params_x5_3(curve);
+		let params_four = setup_params_x5_4(curve);
+		let poseidon_native_three = PoseidonBn254 {
+			params: params_three,
+		};
+		let poseidon_native_four = PoseidonBn254 {
+			params: params_four,
+		};
+
+		// Randomly generated secrets
+		let secret = Fq::rand(rng);
+		let nullifier = Fq::rand(rng);
+
+		// Public data
+		let chain_id = Fq::from(1u32);
+		let arbitrary_data = Fq::rand(rng);
+		let nullifier_hash = poseidon_native_three
+			.hash_two(&nullifier, &nullifier)
+			.unwrap();
+		let leaf_hash = poseidon_native_four
+			.hash(&[chain_id, secret, nullifier])
+			.unwrap();
+
+		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
+		// scalars, then add leaf_hash as the final leaf
+		const HEIGHT: usize = 6usize;
+		let last_index = 1 << (HEIGHT - 1) - 1;
+		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
+		for i in 0..last_index {
+			leaves[i] = Fq::rand(rng);
+		}
+		leaves[last_index] = leaf_hash;
+		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
+			&leaves,
+			&poseidon_native_three,
+			&[0u8; 32],
+		)
+		.unwrap();
+
+		// Path
+		let path = tree.generate_membership_proof(last_index as u64);
+
+		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+		roots[0] = path
+			.calculate_root(&leaf_hash, &poseidon_native_three)
+			.unwrap();
+
+		// Create AnchorCircuit
+		let mut anchor =
+			AnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
+				chain_id,
+				secret,
+				nullifier,
+				nullifier_hash,
+				path,
+				roots,
+				arbitrary_data,
+				poseidon_native_three,
+				poseidon_native_four,
+			);
+
+		// Prover and verifier disagree on public inputs:
+		// The order of public inputs is [chain_id, nullifier_hash, roots,
+		// arbitrary_data, -roots ]
+		let verifier_pi = vec![
+			chain_id.double(), // Verifier has different chain id
+			nullifier_hash,
+			arbitrary_data,
+			-roots[0],
+			-roots[1],
+		];
+		let res = prove_then_verify::<Bn254, JubjubParameters, _>(
+			&mut |c| anchor.gadget(c),
+			1 << 17,
+			Some(verifier_pi),
+		);
+		// // Assert that verification failed
+		match res {
+			Err(Error::ProofVerificationError) => (),
+			Err(err) => panic!("Unexpected error: {:?}", err),
+			Ok(()) => panic!("Proof was successfully verified when error wasexpected"),
 		};
 	}
 }

--- a/arkworks-plonk-circuits/src/anchor/mod.rs
+++ b/arkworks-plonk-circuits/src/anchor/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-	merkle_tree::PathGadget, anchor::add_public_input_variable,
+	anchor::add_public_input_variable, merkle_tree::PathGadget,
 	poseidon::poseidon::FieldHasherGadget, set_membership::check_set_membership,
 };
 use ark_ec::{models::TEModelParameters, PairingEngine};
@@ -263,7 +263,11 @@ mod test {
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
 		let proof = {
 			// Create a prover struct
-			let mut prover = Prover::<Bn254, JubjubParameters, SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>>::new(b"anchor");
+			let mut prover = Prover::<
+				Bn254,
+				JubjubParameters,
+				SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
+			>::new(b"anchor");
 			prover.key_transcript(b"key", b"additional seed information");
 			// Add gadgets
 			let _ = anchor.gadget(prover.mut_cs());
@@ -292,9 +296,7 @@ mod test {
 		verifier.preprocess(&ck.powers()).unwrap();
 
 		// Verify proof
-		let res = verifier
-			.verify(&proof, &vk, &public_inputs)
-			.unwrap_err();
+		let res = verifier.verify(&proof, &vk, &public_inputs).unwrap_err();
 		match res {
 			Error::ProofVerificationError => (),
 			err => panic!("Unexpected error: {:?}", err),
@@ -365,7 +367,11 @@ mod test {
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
 		let proof = {
 			// Create a prover struct
-			let mut prover = Prover::<Bn254, JubjubParameters, SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>>::new(b"anchor");
+			let mut prover = Prover::<
+				Bn254,
+				JubjubParameters,
+				SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
+			>::new(b"anchor");
 			prover.key_transcript(b"key", b"additional seed information");
 			// Add gadgets
 			let _ = anchor.gadget(prover.mut_cs());
@@ -471,7 +477,11 @@ mod test {
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
 		let proof = {
 			// Create a prover struct
-			let mut prover = Prover::<Bn254, JubjubParameters, SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>>::new(b"anchor");
+			let mut prover = Prover::<
+				Bn254,
+				JubjubParameters,
+				SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
+			>::new(b"anchor");
 			prover.key_transcript(b"key", b"additional seed information");
 			// Add gadgets
 			let _ = anchor.gadget(prover.mut_cs());
@@ -574,7 +584,11 @@ mod test {
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
 		let proof = {
 			// Create a prover struct
-			let mut prover = Prover::<Bn254, JubjubParameters, SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>>::new(b"anchor");
+			let mut prover = Prover::<
+				Bn254,
+				JubjubParameters,
+				SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
+			>::new(b"anchor");
 			prover.key_transcript(b"key", b"additional seed information");
 			// Add gadgets
 			let _ = anchor.gadget(prover.mut_cs());
@@ -680,7 +694,11 @@ mod test {
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
 		let proof = {
 			// Create a prover struct
-			let mut prover = Prover::<Bn254, JubjubParameters, SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>>::new(b"anchor");
+			let mut prover = Prover::<
+				Bn254,
+				JubjubParameters,
+				SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
+			>::new(b"anchor");
 			prover.key_transcript(b"key", b"additional seed information");
 			// Add gadgets
 			let _ = anchor.gadget(prover.mut_cs());
@@ -783,7 +801,11 @@ mod test {
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
 		let proof = {
 			// Create a prover struct
-			let mut prover = Prover::<Bn254, JubjubParameters, SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>>::new(b"anchor");
+			let mut prover = Prover::<
+				Bn254,
+				JubjubParameters,
+				SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
+			>::new(b"anchor");
 			prover.key_transcript(b"key", b"additional seed information");
 			// Add gadgets
 			let _ = anchor.gadget(prover.mut_cs());

--- a/arkworks-plonk-circuits/src/anchor/mod.rs
+++ b/arkworks-plonk-circuits/src/anchor/mod.rs
@@ -185,9 +185,7 @@ mod test {
 		let path = tree.generate_membership_proof(last_index as u64);
 
 		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-		roots[0] = path
-			.calculate_root(&leaf_hash, &poseidon_native_three)
-			.unwrap();
+		roots[0] = tree.root();
 
 		// Create AnchorCircuit
 		let mut anchor =
@@ -265,9 +263,7 @@ mod test {
 		let path = tree.generate_membership_proof(last_index as u64);
 
 		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-		roots[0] = path
-			.calculate_root(&leaf_hash, &poseidon_native_three)
-			.unwrap();
+		roots[0] = tree.root();
 
 		// Use the wrong secret:
 		let bad_secret = secret.double();
@@ -349,9 +345,7 @@ mod test {
 		let path = tree.generate_membership_proof(last_index as u64);
 
 		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-		roots[0] = path
-			.calculate_root(&leaf_hash, &poseidon_native_three)
-			.unwrap();
+		roots[0] = tree.root();
 
 		// Use the wrong nullifier:
 		let bad_nullifier = nullifier.double();
@@ -433,9 +427,7 @@ mod test {
 		let path = tree.generate_membership_proof(last_index as u64);
 
 		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-		roots[0] = path
-			.calculate_root(&leaf_hash, &poseidon_native_three)
-			.unwrap();
+		roots[0] = tree.root();
 
 		// Use an invalid path
 		let bad_path = tree.generate_membership_proof((last_index - 1) as u64);
@@ -517,9 +509,7 @@ mod test {
 		let path = tree.generate_membership_proof(last_index as u64);
 
 		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-		roots[0] = path
-			.calculate_root(&leaf_hash, &poseidon_native_three)
-			.unwrap();
+		roots[0] = tree.root();
 
 		// Create AnchorCircuit
 		let mut anchor =
@@ -616,9 +606,7 @@ mod test {
 		let path = tree.generate_membership_proof(last_index as u64);
 
 		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-		roots[0] = path
-			.calculate_root(&leaf_hash, &poseidon_native_three)
-			.unwrap();
+		roots[0] = tree.root();
 
 		// Create AnchorCircuit
 		let mut anchor =
@@ -707,9 +695,7 @@ mod test {
 		let path = tree.generate_membership_proof(last_index as u64);
 
 		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-		roots[0] = path
-			.calculate_root(&leaf_hash, &poseidon_native_three)
-			.unwrap();
+		roots[0] = tree.root();
 
 		// Create AnchorCircuit
 		let mut anchor =
@@ -798,9 +784,7 @@ mod test {
 		let path = tree.generate_membership_proof(last_index as u64);
 
 		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-		roots[0] = path
-			.calculate_root(&leaf_hash, &poseidon_native_three)
-			.unwrap();
+		roots[0] = tree.root();
 
 		// Create AnchorCircuit
 		let mut anchor =

--- a/arkworks-plonk-circuits/src/anchor/mod.rs
+++ b/arkworks-plonk-circuits/src/anchor/mod.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use ark_ec::{models::TEModelParameters, PairingEngine};
 use ark_ff::PrimeField;
-use ark_std::{One, Zero};
+use ark_std::{vec, One, Zero};
 use arkworks_gadgets::merkle_tree::simple_merkle::Path;
 use plonk_core::{
 	circuit::Circuit, constraint_system::StandardComposer, error::Error, prelude::Variable,

--- a/arkworks-plonk-circuits/src/anchor/mod.rs
+++ b/arkworks-plonk-circuits/src/anchor/mod.rs
@@ -59,7 +59,6 @@ where
 	}
 }
 
-// Should this include a check that the Merkle root belongs to some root set?
 impl<F, P, HG, const N: usize, const M: usize> Circuit<F, P> for AnchorCircuit<F, P, HG, N, M>
 where
 	F: PrimeField,
@@ -537,22 +536,22 @@ mod test {
 			);
 
 		// Prover and verifier disagree on public inputs:
-		// The order of public inputs is [chain_id, nullifier_hash, roots,
-		// arbitrary_data, -roots ] (Uncomment the following block to verify that)
+		// The order of public inputs is [chain_id, nullifier_hash,
+		// arbitrary_data, roots ] (Uncomment the following block to verify that)
 		// let mut composer = StandardComposer::<Fq, JubjubParameters>::new();
 		// let _ = anchor.gadget(&mut composer);
 		// println!("The public input positions are {:?}", composer.pi_positions());
 		// let prover_pi = composer.construct_dense_pi_vec();
 		// assert_eq!(
 		// 	[prover_pi[3], prover_pi[4], prover_pi[5], prover_pi[14355],
-		// prover_pi[14356]], 	[chain_id, nullifier_hash, arbitrary_data, -roots[0],
-		// -roots[1]]);
+		// prover_pi[14356]], 	[chain_id, nullifier_hash, arbitrary_data, roots[0],
+		// roots[1]]);
 		let verifier_pi = vec![
 			chain_id,
 			nullifier_hash,
 			arbitrary_data,
-			-roots[0].double(), // Verifier has different root set
-			-roots[1],
+			roots[0].double(), // Verifier has different root set
+			roots[1],
 		];
 		let res = prove_then_verify::<Bn254, JubjubParameters, _>(
 			&mut |c| anchor.gadget(c),
@@ -636,14 +635,14 @@ mod test {
 			);
 
 		// Prover and verifier disagree on public inputs:
-		// The order of public inputs is [chain_id, nullifier_hash, roots,
-		// arbitrary_data, -roots ]
+		// The order of public inputs is [chain_id, nullifier_hash,
+		// arbitrary_data, roots ]
 		let verifier_pi = vec![
 			chain_id,
 			nullifier_hash.double(), // Verifier has different nullifier hash
 			arbitrary_data,
-			-roots[0],
-			-roots[1],
+			roots[0],
+			roots[1],
 		];
 		let res = prove_then_verify::<Bn254, JubjubParameters, _>(
 			&mut |c| anchor.gadget(c),
@@ -727,14 +726,14 @@ mod test {
 			);
 
 		// Prover and verifier disagree on public inputs:
-		// The order of public inputs is [chain_id, nullifier_hash, roots,
-		// arbitrary_data, -roots ]
+		// The order of public inputs is [chain_id, nullifier_hash,
+		// arbitrary_data, roots ]
 		let verifier_pi = vec![
 			chain_id,
 			nullifier_hash,
 			arbitrary_data.double(), // Verifier has different arbitrary data
-			-roots[0],
-			-roots[1],
+			roots[0],
+			roots[1],
 		];
 		let res = prove_then_verify::<Bn254, JubjubParameters, _>(
 			&mut |c| anchor.gadget(c),
@@ -818,14 +817,14 @@ mod test {
 			);
 
 		// Prover and verifier disagree on public inputs:
-		// The order of public inputs is [chain_id, nullifier_hash, roots,
-		// arbitrary_data, -roots ]
+		// The order of public inputs is [chain_id, nullifier_hash,
+		// arbitrary_data, roots ]
 		let verifier_pi = vec![
 			chain_id.double(), // Verifier has different chain id
 			nullifier_hash,
 			arbitrary_data,
-			-roots[0],
-			-roots[1],
+			roots[0],
+			roots[1],
 		];
 		let res = prove_then_verify::<Bn254, JubjubParameters, _>(
 			&mut |c| anchor.gadget(c),

--- a/arkworks-plonk-circuits/src/anchor/mod.rs
+++ b/arkworks-plonk-circuits/src/anchor/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-	anchor::add_public_input_variable, merkle_tree::PathGadget,
+	mixer::add_public_input_variable, merkle_tree::PathGadget,
 	poseidon::poseidon::FieldHasherGadget, set_membership::check_set_membership,
 };
 use ark_ec::{models::TEModelParameters, PairingEngine};

--- a/arkworks-plonk-circuits/src/anchor/mod.rs
+++ b/arkworks-plonk-circuits/src/anchor/mod.rs
@@ -189,7 +189,7 @@ mod test {
 
 		// Create AnchorCircuit
 		let mut anchor =
-			AnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
+			AnchorCircuit::<Fq, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
 				chain_id,
 				secret,
 				nullifier,
@@ -270,7 +270,7 @@ mod test {
 
 		// Create AnchorCircuit
 		let mut anchor =
-			AnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
+			AnchorCircuit::<Fq, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
 				chain_id,
 				bad_secret,
 				nullifier,
@@ -352,7 +352,7 @@ mod test {
 
 		// Create AnchorCircuit
 		let mut anchor =
-			AnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
+			AnchorCircuit::<Fq, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
 				chain_id,
 				secret,
 				bad_nullifier,
@@ -434,7 +434,7 @@ mod test {
 
 		// Create AnchorCircuit
 		let mut anchor =
-			AnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
+			AnchorCircuit::<Fq, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
 				chain_id,
 				secret,
 				nullifier,
@@ -513,7 +513,7 @@ mod test {
 
 		// Create AnchorCircuit
 		let mut anchor =
-			AnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
+			AnchorCircuit::<Fq, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
 				chain_id,
 				secret,
 				nullifier,
@@ -610,7 +610,7 @@ mod test {
 
 		// Create AnchorCircuit
 		let mut anchor =
-			AnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
+			AnchorCircuit::<Fq, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
 				chain_id,
 				secret,
 				nullifier,
@@ -699,7 +699,7 @@ mod test {
 
 		// Create AnchorCircuit
 		let mut anchor =
-			AnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
+			AnchorCircuit::<Fq, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
 				chain_id,
 				secret,
 				nullifier,
@@ -788,7 +788,7 @@ mod test {
 
 		// Create AnchorCircuit
 		let mut anchor =
-			AnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
+			AnchorCircuit::<Fq, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
 				chain_id,
 				secret,
 				nullifier,

--- a/arkworks-plonk-circuits/src/lib.rs
+++ b/arkworks-plonk-circuits/src/lib.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[macro_use]
+pub extern crate ark_std;
+
 pub mod anchor;
 pub mod merkle_tree;
 pub mod mixer;

--- a/arkworks-plonk-circuits/src/lib.rs
+++ b/arkworks-plonk-circuits/src/lib.rs
@@ -1,9 +1,9 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+pub mod anchor;
 pub mod merkle_tree;
 pub mod mixer;
 pub mod poseidon;
 pub mod set_membership;
 pub mod utils;
-pub mod anchor;
 pub mod vanchor;

--- a/arkworks-plonk-circuits/src/lib.rs
+++ b/arkworks-plonk-circuits/src/lib.rs
@@ -6,3 +6,4 @@ pub mod poseidon;
 pub mod set_membership;
 pub mod utils;
 pub mod anchor;
+pub mod vanchor;

--- a/arkworks-plonk-circuits/src/lib.rs
+++ b/arkworks-plonk-circuits/src/lib.rs
@@ -5,3 +5,4 @@ pub mod mixer;
 pub mod poseidon;
 pub mod set_membership;
 pub mod utils;
+pub mod anchor;

--- a/arkworks-plonk-circuits/src/mixer/mod.rs
+++ b/arkworks-plonk-circuits/src/mixer/mod.rs
@@ -123,12 +123,10 @@ where
 #[cfg(test)]
 mod test {
 	use super::MixerCircuit;
-	use crate::{poseidon::poseidon::PoseidonGadget, utils::gadget_tester};
-	use ark_bn254::{Bn254, Fr as Bn254Fr};
+	use crate::{poseidon::poseidon::PoseidonGadget, utils::prove_then_verify};
+	use ark_bn254::Bn254;
 	use ark_ed_on_bn254::{EdwardsParameters as JubjubParameters, Fq};
 	use ark_ff::Field;
-	use ark_poly::polynomial::univariate::DensePolynomial;
-	use ark_poly_commit::{kzg10::UniversalParams, sonic_pc::SonicKZG10, PolynomialCommitment};
 	use ark_std::test_rng;
 	use arkworks_gadgets::{
 		ark_std::UniformRand,
@@ -136,10 +134,7 @@ mod test {
 		poseidon::field_hasher::{FieldHasher, Poseidon},
 	};
 	use arkworks_utils::utils::common::{setup_params_x5_3, Curve};
-	use plonk_core::{
-		prelude::*,
-		proof_system::{Prover, Verifier},
-	};
+	use plonk_core::prelude::*;
 
 	type PoseidonBn254 = Poseidon<Fq>;
 
@@ -191,8 +186,16 @@ mod test {
 			poseidon_native,
 		);
 
-		let res = gadget_tester::<Bn254, JubjubParameters, _>(&mut mixer, 1 << 17);
-		assert!(res.is_ok(), "{:?}", res.err().unwrap());
+		// Prove then verify
+		let res = prove_then_verify::<Bn254, JubjubParameters, _>(
+			&mut |c| mixer.gadget(c),
+			1 << 17,
+			None,
+		);
+		match res {
+			Ok(()) => (),
+			Err(err) => panic!("Unexpected error: {:?}", err),
+		};
 	}
 
 	#[test]
@@ -228,7 +231,6 @@ mod test {
 		)
 		.unwrap();
 		let root = tree.root();
-		let bad_root = root.double();
 
 		// Path
 		let path = tree.generate_membership_proof(last_index as u64);
@@ -239,57 +241,24 @@ mod test {
 			nullifier,
 			nullifier_hash,
 			path,
-			bad_root,
+			root,
 			arbitrary_data,
 			poseidon_native,
 		);
 
-		// Fill a composer to extract the public_inputs
-		let mut composer = StandardComposer::<Fq, JubjubParameters>::new();
-		let _ = mixer.gadget(&mut composer);
-		let public_inputs = composer.construct_dense_pi_vec();
+		// Use a different root for the verifier
+		let verifier_public_inputs = vec![nullifier_hash, root.double(), arbitrary_data];
 
-		// Go through proof generation/verification
-		let u_params: UniversalParams<Bn254> =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
-		let proof = {
-			// Create a prover struct
-			let mut prover =
-				Prover::<Fq, JubjubParameters, SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>>::new(
-					b"mixer",
-				);
-			prover.key_transcript(b"key", b"additional seed information");
-			// Add gadgets
-			let _ = mixer.gadget(prover.mut_cs());
-			// Commit Key (being lazy with error)
-			let (ck, _) =
-				SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-					.unwrap();
-			// Preprocess circuit
-			let _ = prover.preprocess(&ck);
-			// Compute Proof
-			prover.prove(&ck).unwrap()
-		};
-
-		// Verifier's view
-
-		// Create a Verifier object
-		let mut verifier = Verifier::new(b"mixer");
-		verifier.key_transcript(b"key", b"additional seed information");
-		// Add gadgets
-		let _ = mixer.gadget(verifier.mut_cs());
-		// Compute Commit and Verifier key
-		let (ck, vk) =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-				.unwrap();
-		// Preprocess circuit
-		verifier.preprocess(&ck).unwrap();
-
-		// Verify proof
-		let res = verifier.verify(&proof, &vk, &public_inputs).unwrap_err();
+		// Prove then verify
+		let res = prove_then_verify::<Bn254, JubjubParameters, _>(
+			&mut |c| mixer.gadget(c),
+			1 << 17,
+			Some(verifier_public_inputs),
+		);
 		match res {
-			Error::ProofVerificationError => (),
-			err => panic!("Unexpected error: {:?}", err),
+			Err(Error::ProofVerificationError) => (),
+			Err(err) => panic!("Unexpected error: {:?}", err),
+			Ok(()) => panic!("Proof was successfully verified when error was expected"),
 		};
 	}
 
@@ -344,52 +313,18 @@ mod test {
 			poseidon_native,
 		);
 
-		// Fill a composer to extract the public_inputs
-		let mut composer = StandardComposer::<Fq, JubjubParameters>::new();
-		let _ = mixer.gadget(&mut composer);
-		let public_inputs = composer.construct_dense_pi_vec();
 
-		// Go through proof generation/verification
-		let u_params: UniversalParams<Bn254> =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
-		let proof = {
-			// Create a prover struct
-			let mut prover =
-				Prover::<Fq, JubjubParameters, SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>>::new(
-					b"mixer",
-				);
-			prover.key_transcript(b"key", b"additional seed information");
-			// Add gadgets
-			let _ = mixer.gadget(prover.mut_cs());
-			// Commit Key (being lazy with error)
-			let (ck, _) =
-				SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-					.unwrap();
-			// Preprocess circuit
-			let _ = prover.preprocess(&ck);
-			// Compute Proof
-			prover.prove(&ck).unwrap()
-		};
+		// Prove then verify
+		let res = prove_then_verify::<Bn254, JubjubParameters, _>(
+			&mut |c| mixer.gadget(c),
+			1 << 17,
+			None, 	// No need to give verifier different public data
 
-		// Verifier's view
-
-		// Create a Verifier object
-		let mut verifier = Verifier::new(b"mixer");
-		verifier.key_transcript(b"key", b"additional seed information");
-		// Add gadgets
-		let _ = mixer.gadget(verifier.mut_cs());
-		// Compute Commit and Verifier key
-		let (ck, vk) =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-				.unwrap();
-		// Preprocess circuit
-		verifier.preprocess(&ck).unwrap();
-
-		// Verify proof
-		let res = verifier.verify(&proof, &vk, &public_inputs).unwrap_err();
+		);
 		match res {
-			Error::ProofVerificationError => (),
-			err => panic!("Unexpected error: {:?}", err),
+			Err(Error::ProofVerificationError) => (),
+			Err(err) => panic!("Unexpected error: {:?}", err),
+			Ok(()) => panic!("Proof was successfully verified when error was expected"),
 		};
 	}
 
@@ -430,7 +365,7 @@ mod test {
 		// Path
 		let path = tree.generate_membership_proof(last_index as u64);
 
-		// An incorrect secret value to use below
+		// Use a bad nullifier value:
 		let bad_nullifier = nullifier.double();
 
 		// Create MixerCircuit
@@ -444,52 +379,16 @@ mod test {
 			poseidon_native,
 		);
 
-		// Fill a composer to extract the public_inputs
-		let mut composer = StandardComposer::<Fq, JubjubParameters>::new();
-		let _ = mixer.gadget(&mut composer);
-		let public_inputs = composer.construct_dense_pi_vec();
-
-		// Go through proof generation/verification
-		let u_params: UniversalParams<Bn254> =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
-		let proof = {
-			// Create a prover struct
-			let mut prover =
-				Prover::<Fq, JubjubParameters, SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>>::new(
-					b"mixer",
-				);
-			prover.key_transcript(b"key", b"additional seed information");
-			// Add gadgets
-			let _ = mixer.gadget(prover.mut_cs());
-			// Commit Key (being lazy with error)
-			let (ck, _) =
-				SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-					.unwrap();
-			// Preprocess circuit
-			let _ = prover.preprocess(&ck);
-			// Compute Proof
-			prover.prove(&ck).unwrap()
-		};
-
-		// Verifier's view
-
-		// Create a Verifier object
-		let mut verifier = Verifier::new(b"mixer");
-		verifier.key_transcript(b"key", b"additional seed information");
-		// Add gadgets
-		let _ = mixer.gadget(verifier.mut_cs());
-		// Compute Commit and Verifier key
-		let (ck, vk) =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-				.unwrap();
-		// Preprocess circuit
-		verifier.preprocess(&ck).unwrap();
-
-		// Verify proof
-		let res = verifier.verify(&proof, &vk, &public_inputs).unwrap_err();
+		// Prove then verify
+		let res = prove_then_verify::<Bn254, JubjubParameters, _>(
+			&mut |c| mixer.gadget(c),
+			1 << 17,
+			None, 		// No need to give verifier different public inputs
+		);
 		match res {
-			Error::ProofVerificationError => (),
-			err => panic!("Unexpected error: {:?}", err),
+			Err(Error::ProofVerificationError) => (),
+			Err(err) => panic!("Unexpected error: {:?}", err),
+			Ok(()) => panic!("Proof was successfully verified when error was expected"),
 		};
 	}
 
@@ -541,52 +440,17 @@ mod test {
 			poseidon_native,
 		);
 
-		// Fill a composer to extract the public_inputs
-		let mut composer = StandardComposer::<Fq, JubjubParameters>::new();
-		let _ = mixer.gadget(&mut composer);
-		let public_inputs = composer.construct_dense_pi_vec();
-
-		// Go through proof generation/verification
-		let u_params: UniversalParams<Bn254> =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
-		let proof = {
-			// Create a prover struct
-			let mut prover =
-				Prover::<Fq, JubjubParameters, SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>>::new(
-					b"mixer",
-				);
-			prover.key_transcript(b"key", b"additional seed information");
-			// Add gadgets
-			let _ = mixer.gadget(prover.mut_cs());
-			// Commit Key (being lazy with error)
-			let (ck, _) =
-				SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-					.unwrap();
-			// Preprocess circuit
-			let _ = prover.preprocess(&ck);
-			// Compute Proof
-			prover.prove(&ck).unwrap()
-		};
-
-		// Verifier's view
-
-		// Create a Verifier object
-		let mut verifier = Verifier::new(b"mixer");
-		verifier.key_transcript(b"key", b"additional seed information");
-		// Add gadgets
-		let _ = mixer.gadget(verifier.mut_cs());
-		// Compute Commit and Verifier key
-		let (ck, vk) =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-				.unwrap();
-		// Preprocess circuit
-		verifier.preprocess(&ck).unwrap();
-
-		// Verify proof
-		let res = verifier.verify(&proof, &vk, &public_inputs).unwrap_err();
+		// (No need to give verifier different public inputs)
+		// Prove then verify
+		let res = prove_then_verify::<Bn254, JubjubParameters, _>(
+			&mut |c| mixer.gadget(c),
+			1 << 17,
+			None,
+		);
 		match res {
-			Error::ProofVerificationError => (),
-			err => panic!("Unexpected error: {:?}", err),
+			Err(Error::ProofVerificationError) => (),
+			Err(err) => panic!("Unexpected error: {:?}", err),
+			Ok(()) => panic!("Proof was successfully verified when error was expected"),
 		};
 	}
 
@@ -627,66 +491,29 @@ mod test {
 		// Path
 		let path = tree.generate_membership_proof(last_index as u64);
 
-		// Incorrect nullifier hash to use below
-		let bad_nullifier_hash = nullifier_hash.double();
-
 		// Create MixerCircuit
 		let mut mixer = MixerCircuit::<Fq, JubjubParameters, PoseidonGadget, HEIGHT>::new(
 			secret,
 			nullifier,
-			bad_nullifier_hash,
+			nullifier_hash,
 			path,
 			root,
 			arbitrary_data,
 			poseidon_native,
 		);
 
-		// Fill a composer to extract the public_inputs
-		let mut composer = StandardComposer::<Fq, JubjubParameters>::new();
-		let _ = mixer.gadget(&mut composer);
-		let public_inputs = composer.construct_dense_pi_vec();
-
-		// Go through proof generation/verification
-		let u_params: UniversalParams<Bn254> =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
-		let proof = {
-			// Create a prover struct
-			let mut prover =
-				Prover::<Fq, JubjubParameters, SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>>::new(
-					b"mixer",
-				);
-			prover.key_transcript(b"key", b"additional seed information");
-			// Add gadgets
-			let _ = mixer.gadget(prover.mut_cs());
-			// Commit Key (being lazy with error)
-			let (ck, _) =
-				SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-					.unwrap();
-			// Preprocess circuit
-			let _ = prover.preprocess(&ck);
-			// Compute Proof
-			prover.prove(&ck).unwrap()
-		};
-
-		// Verifier's view
-
-		// Create a Verifier object
-		let mut verifier = Verifier::new(b"mixer");
-		verifier.key_transcript(b"key", b"additional seed information");
-		// Add gadgets
-		let _ = mixer.gadget(verifier.mut_cs());
-		// Compute Commit and Verifier key
-		let (ck, vk) =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-				.unwrap();
-		// Preprocess circuit
-		verifier.preprocess(&ck).unwrap();
-
-		// Verify proof
-		let res = verifier.verify(&proof, &vk, &public_inputs).unwrap_err();
+		// Give the verifier a different nullifier hash
+		let verifier_public_inputs = vec![nullifier_hash.double(), root, arbitrary_data];
+		// Prove then verify
+		let res = prove_then_verify::<Bn254, JubjubParameters, _>(
+			&mut |c| mixer.gadget(c),
+			1 << 17,
+			Some(verifier_public_inputs),
+		);
 		match res {
-			Error::ProofVerificationError => (),
-			err => panic!("Unexpected error: {:?}", err),
+			Err(Error::ProofVerificationError) => (),
+			Err(err) => panic!("Unexpected error: {:?}", err),
+			Ok(()) => panic!("Proof was successfully verified when error was expected"),
 		};
 	}
 
@@ -738,57 +565,18 @@ mod test {
 			poseidon_native,
 		);
 
-		// Fill a composer to extract the public_inputs
-		let mut composer = StandardComposer::<Fq, JubjubParameters>::new();
-		let _ = mixer.gadget(&mut composer);
-		let mut public_inputs = composer.construct_dense_pi_vec();
-
-		// Go through proof generation/verification
-		let u_params: UniversalParams<Bn254> =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
-		let proof = {
-			// Create a prover struct
-			let mut prover =
-				Prover::<Fq, JubjubParameters, SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>>::new(
-					b"mixer",
-				);
-			prover.key_transcript(b"key", b"additional seed information");
-			// Add gadgets
-			let _ = mixer.gadget(prover.mut_cs());
-			// Commit Key (being lazy with error)
-			let (ck, _) =
-				SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-					.unwrap();
-			// Preprocess circuit
-			let _ = prover.preprocess(&ck);
-			// Compute Proof
-			prover.prove(&ck).unwrap()
-		};
-
-		// Verifier's view
-
-		// Create a Verifier object
-		let mut verifier = Verifier::new(b"mixer");
-		verifier.key_transcript(b"key", b"additional seed information");
-		// Add gadgets
-		let _ = mixer.gadget(verifier.mut_cs());
-		// Compute Commit and Verifier key
-		let (ck, vk) =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-				.unwrap();
-		// Preprocess circuit
-		verifier.preprocess(&ck).unwrap();
-
-		// The arbitrary data is stored at index 5 of the public input vector:
-		assert_eq!(arbitrary_data, public_inputs[5]);
-		// Modify the arbitrary data so that prover/verifier disagree
-		public_inputs[5].double_in_place();
-
-		// Verify proof
-		let res = verifier.verify(&proof, &vk, &public_inputs).unwrap_err();
+		// Give the verifier different arbitrary data
+		let verifier_public_inputs = vec![nullifier_hash, root, arbitrary_data.double()];
+		// Prove then verify
+		let res = prove_then_verify::<Bn254, JubjubParameters, _>(
+			&mut |c| mixer.gadget(c),
+			1 << 17,
+			Some(verifier_public_inputs),
+		);
 		match res {
-			Error::ProofVerificationError => (),
-			err => panic!("Unexpected error: {:?}", err),
+			Err(Error::ProofVerificationError) => (),
+			Err(err) => panic!("Unexpected error: {:?}", err),
+			Ok(()) => panic!("Proof was successfully verified when error was expected"),
 		};
 	}
 }

--- a/arkworks-plonk-circuits/src/mixer/mod.rs
+++ b/arkworks-plonk-circuits/src/mixer/mod.rs
@@ -440,12 +440,11 @@ mod test {
 			poseidon_native,
 		);
 
-		// (No need to give verifier different public inputs)
 		// Prove then verify
 		let res = prove_then_verify::<Bn254, JubjubParameters, _>(
 			&mut |c| mixer.gadget(c),
 			1 << 17,
-			None,
+			None,	// No need to give verifier different public inputs
 		);
 		match res {
 			Err(Error::ProofVerificationError) => (),

--- a/arkworks-plonk-circuits/src/mixer/mod.rs
+++ b/arkworks-plonk-circuits/src/mixer/mod.rs
@@ -313,13 +313,11 @@ mod test {
 			poseidon_native,
 		);
 
-
 		// Prove then verify
 		let res = prove_then_verify::<Bn254, JubjubParameters, _>(
 			&mut |c| mixer.gadget(c),
 			1 << 17,
-			None, 	// No need to give verifier different public data
-
+			None, // No need to give verifier different public data
 		);
 		match res {
 			Err(Error::ProofVerificationError) => (),
@@ -383,7 +381,7 @@ mod test {
 		let res = prove_then_verify::<Bn254, JubjubParameters, _>(
 			&mut |c| mixer.gadget(c),
 			1 << 17,
-			None, 		// No need to give verifier different public inputs
+			None, // No need to give verifier different public inputs
 		);
 		match res {
 			Err(Error::ProofVerificationError) => (),
@@ -444,7 +442,7 @@ mod test {
 		let res = prove_then_verify::<Bn254, JubjubParameters, _>(
 			&mut |c| mixer.gadget(c),
 			1 << 17,
-			None,	// No need to give verifier different public inputs
+			None, // No need to give verifier different public inputs
 		);
 		match res {
 			Err(Error::ProofVerificationError) => (),

--- a/arkworks-plonk-circuits/src/set_membership/mod.rs
+++ b/arkworks-plonk-circuits/src/set_membership/mod.rs
@@ -24,8 +24,8 @@ where
 	for x in set.iter() {
 		let diff = composer.arithmetic_gate(|gate| {
 			gate.witness(member, member, None)
-				.add(F::zero(), F::one())
-				.pi(-*x)
+				.add(F::zero(), -F::one())
+				.pi(*x)
 		});
 		diffs.push(diff);
 	}
@@ -63,8 +63,8 @@ where
 	for x in set.iter() {
 		let diff = composer.arithmetic_gate(|gate| {
 			gate.witness(member, member, None)
-				.add(F::zero(), F::one())
-				.pi(-*x)
+				.add(F::zero(), -F::one())
+				.pi(*x)
 		});
 		diffs.push(diff);
 	}

--- a/arkworks-plonk-circuits/src/set_membership/mod.rs
+++ b/arkworks-plonk-circuits/src/set_membership/mod.rs
@@ -10,7 +10,7 @@ use plonk_core::{
 /// and the output is added as a variable to the StandardComposer.
 /// The set is assumed to consist of public inputs, such as roots
 /// of various Merkle trees.
-fn check_set_membership<F, P>(
+pub fn check_set_membership<F, P>(
 	composer: &mut StandardComposer<F, P>,
 	set: &Vec<F>,
 	member: Variable,

--- a/arkworks-plonk-circuits/src/set_membership/mod.rs
+++ b/arkworks-plonk-circuits/src/set_membership/mod.rs
@@ -40,6 +40,48 @@ where
 	composer.is_zero_with_output(accumulator)
 }
 
+/// Similar to the check_set_membership function,
+/// except that it accepts an `is_enabled` argument
+/// that turns the set membership check on/off.
+/// Intended usage is when verifying input UTXOs: the
+/// validity of an input only needs to be verified if
+/// its amount is non-zero, so adding the input amount
+/// as the `is_enabled` argument is a way of turning the
+/// set membership check on only when it is needed.
+pub fn check_set_membership_is_enabled<F, P>(
+	composer: &mut StandardComposer<F, P>,
+	set: &Vec<F>,
+	member: Variable,
+	is_enabled: Variable,
+) -> Variable
+where
+	F: PrimeField,
+	P: TEModelParameters<BaseField = F>,
+{
+	// Compute all differences between `member` and set elements
+	let mut diffs = Vec::new();
+	for x in set.iter() {
+		let diff = composer.arithmetic_gate(|gate| {
+			gate.witness(member, member, None)
+				.add(F::zero(), F::one())
+				.pi(-*x)
+		});
+		diffs.push(diff);
+	}
+
+	// Accumulate the product of all differences
+	let mut accumulator = composer.add_witness_to_circuit_description(F::one());
+	for diff in diffs {
+		accumulator =
+			composer.arithmetic_gate(|gate| gate.witness(accumulator, diff, None).mul(F::one()));
+	}
+	// Multiply accumulated product by `is_enabled`
+	accumulator =
+		composer.arithmetic_gate(|gate| gate.witness(accumulator, is_enabled, None).mul(F::one()));
+
+	composer.is_zero_with_output(accumulator)
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
 	//copied from ark-plonk
@@ -68,6 +110,40 @@ pub(crate) mod tests {
 		let member = composer.add_input(Fq::from(4u32));
 
 		let result_private = check_set_membership(&mut composer, &set, member);
+		composer.assert_equal(result_private, zero);
+		composer.check_circuit_satisfied();
+	}
+
+	#[test]
+	fn test_verify_set_membership_enabled_functions() {
+		let set = vec![Fq::from(1u32), Fq::from(2u32), Fq::from(3u32)];
+
+		let mut composer = StandardComposer::<Fq, JubjubParameters>::new();
+		let one = composer.add_input(Fq::from(1u32));
+		// This is not a member of the set
+		let member = composer.add_input(Fq::from(4u32));
+		// We set `is_enabled` to 0, so check should pass
+		let is_enabled = composer.add_input(Fq::from(0u32));
+
+		let result_private =
+			check_set_membership_is_enabled(&mut composer, &set, member, is_enabled);
+		composer.assert_equal(result_private, one);
+		composer.check_circuit_satisfied();
+	}
+
+	#[test]
+	fn test_fail_to_verify_set_membership_enabled_functions() {
+		let set = vec![Fq::from(1u32), Fq::from(2u32), Fq::from(3u32)];
+
+		let mut composer = StandardComposer::<Fq, JubjubParameters>::new();
+		let zero = composer.zero_var();
+		// This is not a member of the set
+		let member = composer.add_input(Fq::from(4u32));
+		// We set `is_enabled` to 1, so check should fail
+		let is_enabled = composer.add_input(Fq::from(1u32));
+
+		let result_private =
+			check_set_membership_is_enabled(&mut composer, &set, member, is_enabled);
 		composer.assert_equal(result_private, zero);
 		composer.check_circuit_satisfied();
 	}

--- a/arkworks-plonk-circuits/src/utils.rs
+++ b/arkworks-plonk-circuits/src/utils.rs
@@ -1,6 +1,11 @@
 use ark_ec::{models::TEModelParameters, PairingEngine};
+use ark_ff::PrimeField;
 use ark_poly::polynomial::univariate::DensePolynomial;
-use ark_poly_commit::{kzg10::KZG10, sonic_pc::SonicKZG10, PolynomialCommitment};
+use ark_poly_commit::{
+	kzg10::{UniversalParams, KZG10},
+	sonic_pc::SonicKZG10,
+	PolynomialCommitment,
+};
 use ark_std::test_rng;
 use plonk_core::{
 	prelude::*,
@@ -75,4 +80,232 @@ pub(crate) fn gadget_tester<
 
 	// Verify proof
 	Ok(verifier.verify(&proof, &sonic_vk, &public_inputs)?)
+}
+
+/// Helper function that accepts a composer that has already been filled,
+/// generates a proof, then verifies it.
+/// Probably want it to  accept a public inputs argument (could be optional)
+pub(crate) fn prove_then_verify<
+	E: PairingEngine,
+	P: TEModelParameters<BaseField = E::Fr>,
+	T: FnMut(&mut StandardComposer<E::Fr, P>) -> Result<(), Error>,
+>(
+	// gadget: fn(&mut StandardComposer<E::Fr, P>),
+	gadget: &mut T,
+	max_degree: usize,
+	verifier_public_inputs: Option<Vec<E::Fr>>,
+) -> Result<(), Error> {
+	let rng = &mut test_rng();
+
+	// Fill a composer to extract the public_inputs
+	let mut composer = StandardComposer::<E::Fr, P>::new();
+	let _ = gadget(&mut composer);
+
+	// Check for verifier public inputs argument, otherwise
+	// verifier uses the same public inputs as the prover
+	let public_inputs = match verifier_public_inputs {
+		Some(pi) => {
+			// The provided values need to be turned into a dense public input vector,
+			// which means putting each value in the position corresponding to its gate
+			let mut pi_dense = vec![E::Fr::from(0u32); composer.circuit_size()];
+			let pi_positions = composer.pi_positions();
+			pi_positions.iter().zip(pi).for_each(|(position, value)| {
+				pi_dense[*position] = value;
+			});
+			pi_dense
+		}
+		None => composer.construct_dense_pi_vec(),
+	};
+
+	// Go through proof generation/verification
+	let u_params: UniversalParams<E> =
+		SonicKZG10::<E, DensePolynomial<E::Fr>>::setup(max_degree, None, rng).unwrap();
+	let proof = {
+		// Create a prover struct
+		let mut prover =
+			Prover::<E::Fr, P, SonicKZG10<E, DensePolynomial<E::Fr>>>::new(b"test circuit");
+		prover.key_transcript(b"key", b"additional seed information");
+		// Add gadgets
+		let _ = gadget(prover.mut_cs());
+		// Commit Key (being lazy with error)
+		let (ck, _) =
+			SonicKZG10::<E, DensePolynomial<E::Fr>>::trim(&u_params, max_degree, 0, None).unwrap();
+		// Preprocess circuit
+		let _ = prover.preprocess(&ck);
+		// Compute Proof
+		prover.prove(&ck)?
+	};
+
+	// Verifier's view
+
+	// Create a Verifier object
+	let mut verifier =
+		Verifier::<E::Fr, P, SonicKZG10<E, DensePolynomial<E::Fr>>>::new(b"test circuit");
+	verifier.key_transcript(b"key", b"additional seed information");
+	// Add gadgets
+	let _ = gadget(verifier.mut_cs());
+	// Compute Commit and Verifier key
+	let (ck, vk) =
+		SonicKZG10::<E, DensePolynomial<E::Fr>>::trim(&u_params, max_degree, 0, None).unwrap();
+	// Preprocess circuit
+	verifier.preprocess(&ck)?;
+	// Verify proof
+	verifier.verify(&proof, &vk, &public_inputs)?;
+
+	Ok(())
+}
+
+// I used the MixerCircuit to test the new helper function:
+// TODO: Include a more minimal example to show how it's used
+#[cfg(test)]
+mod test {
+	use crate::{
+		mixer::MixerCircuit,
+		poseidon::poseidon::PoseidonGadget,
+		utils::{gadget_tester, prove_then_verify},
+	};
+	use ark_bn254::Bn254;
+	use ark_ed_on_bn254::{EdwardsParameters as JubjubParameters, Fq};
+	use ark_ff::Field;
+	use ark_poly::polynomial::univariate::DensePolynomial;
+	use ark_poly_commit::{kzg10::UniversalParams, sonic_pc::SonicKZG10, PolynomialCommitment};
+	use ark_std::test_rng;
+	use arkworks_gadgets::{
+		ark_std::UniformRand,
+		merkle_tree::simple_merkle::SparseMerkleTree,
+		poseidon::field_hasher::{FieldHasher, Poseidon},
+	};
+	use arkworks_utils::utils::common::{setup_params_x5_3, Curve};
+	use plonk_core::{
+		prelude::*,
+		proof_system::{Prover, Verifier},
+	};
+
+	type PoseidonBn254 = Poseidon<Fq>;
+
+	#[test]
+	fn check_new_gadget_tester_on_success() {
+		let rng = &mut test_rng();
+		let curve = Curve::Bn254;
+
+		let params = setup_params_x5_3(curve);
+		let poseidon_native = PoseidonBn254 { params };
+
+		// Randomly generated secrets
+		let secret = Fq::rand(rng);
+		let nullifier = Fq::rand(rng);
+
+		// Public data
+		let arbitrary_data = Fq::rand(rng);
+		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
+		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
+
+		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
+		// scalars, then add leaf_hash as the final leaf
+		const HEIGHT: usize = 6usize;
+		let last_index = 1 << (HEIGHT - 1) - 1;
+		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
+		for i in 0..last_index {
+			leaves[i] = Fq::rand(rng);
+		}
+		leaves[last_index] = leaf_hash;
+		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
+			&leaves,
+			&poseidon_native,
+			&[0u8; 32],
+		)
+		.unwrap();
+		let root = tree.root();
+
+		// Path
+		let path = tree.generate_membership_proof(last_index as u64);
+
+		// Create MixerCircuit
+		let mut mixer = MixerCircuit::<Fq, JubjubParameters, PoseidonGadget, HEIGHT>::new(
+			secret,
+			nullifier,
+			nullifier_hash,
+			path,
+			root,
+			arbitrary_data,
+			poseidon_native,
+		);
+
+		// Use None argument to give verifier the same public input data
+		// Verify proof
+		let res = prove_then_verify::<Bn254, JubjubParameters, _>(
+			&mut |c| mixer.gadget(c),
+			1 << 17,
+			None,
+		);
+		match res {
+			Ok(()) => (),
+			Err(err) => panic!("Unexpected error: {:?}", err),
+		};
+	}
+
+	#[test]
+	fn check_new_gadget_tester_on_failure() {
+		let rng = &mut test_rng();
+		let curve = Curve::Bn254;
+
+		let params = setup_params_x5_3(curve);
+		let poseidon_native = PoseidonBn254 { params };
+
+		// Randomly generated secrets
+		let secret = Fq::rand(rng);
+		let nullifier = Fq::rand(rng);
+
+		// Public data
+		let arbitrary_data = Fq::rand(rng);
+		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
+		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
+
+		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
+		// scalars, then add leaf_hash as the final leaf
+		const HEIGHT: usize = 6usize;
+		let last_index = 1 << (HEIGHT - 1) - 1;
+		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
+		for i in 0..last_index {
+			leaves[i] = Fq::rand(rng);
+		}
+		leaves[last_index] = leaf_hash;
+		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
+			&leaves,
+			&poseidon_native,
+			&[0u8; 32],
+		)
+		.unwrap();
+		let root = tree.root();
+
+		// Path
+		let path = tree.generate_membership_proof(last_index as u64);
+
+		// Create MixerCircuit
+		let mut mixer = MixerCircuit::<Fq, JubjubParameters, PoseidonGadget, HEIGHT>::new(
+			secret,
+			nullifier,
+			nullifier_hash,
+			path,
+			root,
+			arbitrary_data,
+			poseidon_native,
+		);
+
+		// Give verifier different public input data:
+		let verifier_public_inputs = vec![nullifier_hash.double(), root, arbitrary_data];
+
+		// Verify proof
+		let res = prove_then_verify::<Bn254, JubjubParameters, _>(
+			&mut |c| mixer.gadget(c),
+			1 << 17,
+			Some(verifier_public_inputs),
+		);
+
+		match res {
+			Err(Error::ProofVerificationError) => (),
+			Err(err) => panic!("Unexpected error: {:?}", err),
+			Ok(()) => panic!("Proof was successfully verified when error was expected"),
+		};
+	}
 }

--- a/arkworks-plonk-circuits/src/utils.rs
+++ b/arkworks-plonk-circuits/src/utils.rs
@@ -313,11 +313,12 @@ mod test {
 	/// Gadget to use in the tests below.  Takes two numbers a and b and adds
 	/// constraints to the composer that show the numbers sum to the given
 	/// public input value.
-	/// The prove_then_verify function takes the gadget in the form of a closure, so
-	/// in this case that looks like
-	/// ```&mut | composer | minimal_test_gadget(composer, a, b, public_input) ```
-	/// In the case of a circuit (implementing the Circuit trait) that argument 
-	/// would look like 
+	/// The prove_then_verify function takes the gadget in the form of a
+	/// closure, so in this case that looks like
+	/// ```&mut | composer | minimal_test_gadget(composer, a, b, public_input)
+	/// ```
+	/// In the case of a circuit (implementing the Circuit trait) that argument
+	/// would look like
 	/// ```&mut | composer | circuit.gadget(composer) ```
 	fn minimal_test_gadget<E: PairingEngine, P: TEModelParameters<BaseField = E::Fr>>(
 		composer: &mut StandardComposer<E::Fr, P>,
@@ -388,14 +389,14 @@ mod test {
 		};
 
 		// Another possible sort of failure is that prover and verifier
-		// agree on the public input value but prover's secret witnesses are 
+		// agree on the public input value but prover's secret witnesses are
 		// invalid.  That looks like this:
 		let x = Fq::from(1u32);
 		let y = Fq::from(1u32);
 		let public_input_two = Fq::from(3u32);
 
 		// Observe that `max_degree` has been increased to 2^5. Otherwise
-		// we will have a polynomial commitment error.  This always 
+		// we will have a polynomial commitment error.  This always
 		// happens when the prover tries to generate invalid proofs, and
 		// I believe it has to do with trying to divide one polynomial
 		// by another that does not actually divide it.

--- a/arkworks-plonk-circuits/src/utils.rs
+++ b/arkworks-plonk-circuits/src/utils.rs
@@ -6,7 +6,7 @@ use ark_poly_commit::{
 	sonic_pc::SonicKZG10,
 	PolynomialCommitment,
 };
-use ark_std::test_rng;
+use ark_std::{test_rng, vec::Vec};
 use plonk_core::{
 	prelude::*,
 	proof_system::{Prover, Verifier},

--- a/arkworks-plonk-circuits/src/utils.rs
+++ b/arkworks-plonk-circuits/src/utils.rs
@@ -84,7 +84,8 @@ pub(crate) fn gadget_tester<
 
 /// Helper function that accepts a composer that has already been filled,
 /// generates a proof, then verifies it.
-/// Probably want it to  accept a public inputs argument (could be optional)
+/// Accepts an optional public input argument that can be used to simulate
+/// a situation where prover and verifier disagree on public input values
 pub(crate) fn prove_then_verify<
 	E: PairingEngine,
 	P: TEModelParameters<BaseField = E::Fr>,

--- a/arkworks-plonk-circuits/src/vanchor/mod.rs
+++ b/arkworks-plonk-circuits/src/vanchor/mod.rs
@@ -438,7 +438,6 @@ mod test {
 		// The root set should contain this merkle tree's root
 		in_root_set[0] = merkle_tree.root();
 
-
 		// Output amounts: (remember input amounts sum to 6 and there is also the public
 		// amount)
 		let mut out_amounts = [Fq::from(0u64); OUTS];

--- a/arkworks-plonk-circuits/src/vanchor/mod.rs
+++ b/arkworks-plonk-circuits/src/vanchor/mod.rs
@@ -19,11 +19,8 @@
 use std::ops::Add;
 
 use crate::{
-	merkle_tree::{PathGadget},
-	mixer::add_public_input_variable,
-	poseidon::poseidon::FieldHasherGadget,
-	set_membership::check_set_membership,
-	// vanchor::add_public_input_variable,
+	merkle_tree::PathGadget, mixer::add_public_input_variable,
+	poseidon::poseidon::FieldHasherGadget, set_membership::check_set_membership,
 };
 use ark_ec::{models::TEModelParameters, PairingEngine};
 use ark_ff::PrimeField;
@@ -222,7 +219,7 @@ where
 
 			// Checking if the passed nullifier hash is the same as the calculated one
 			// Optimized version of allocating public nullifier input and constraining
-			// to the calculate one.
+			// to the calculated one.
 			let _ = composer.arithmetic_gate(|gate| {
 				gate.witness(calc_nullifier, calc_nullifier, Some(zero))
 					.add(-F::one(), F::zero())
@@ -235,7 +232,8 @@ where
 
 			// Check if calculated root hash is in the set
 			// TODO: Check membership enabled is needed here.
-			let is_member = check_set_membership(composer, &self.in_root_set.to_vec(), calc_root_hash);
+			let is_member =
+				check_set_membership(composer, &self.in_root_set.to_vec(), calc_root_hash);
 			composer.constrain_to_constant(is_member, F::one(), None);
 
 			// Finally add the amount to the sum
@@ -305,6 +303,8 @@ where
 
 #[cfg(test)]
 mod test {
+	use std::marker::PhantomData;
+
 	use super::VariableAnchorCircuit;
 	use crate::{poseidon::poseidon::PoseidonGadget, utils::gadget_tester};
 	use ark_bn254::{Bn254, Fr as Bn254Fr};
@@ -320,10 +320,12 @@ mod test {
 	use ark_std::test_rng;
 	use arkworks_gadgets::{
 		ark_std::UniformRand,
-		merkle_tree::simple_merkle::SparseMerkleTree,
+		merkle_tree::simple_merkle::{Path, SparseMerkleTree},
 		poseidon::field_hasher::{FieldHasher, Poseidon},
 	};
-	use arkworks_utils::utils::common::{setup_params_x5_3, Curve};
+	use arkworks_utils::utils::common::{
+		setup_params_x5_2, setup_params_x5_3, setup_params_x5_4, setup_params_x5_5, Curve,
+	};
 	use plonk_core::{
 		prelude::*,
 		proof_system::{Prover, Verifier},
@@ -331,765 +333,915 @@ mod test {
 
 	type PoseidonBn254 = Poseidon<Fq>;
 
+	const TREE_HEIGHT: usize = 3;
 	const BRIDGE_SIZE: usize = 2;
 	const INS: usize = 2;
 	const OUTS: usize = 2;
 
+	// 	// Helper to set up the necessary Poseidon hash functions
+	// pub struct VariableAnchorPoseidonSetup<F, P>
+	// where
+	// 	F: PrimeField,
+	// 	P: TEModelParameters<BaseField = F>,
+	// {
+	// 	// These are labeled by their width
+	// 	params2: PoseidonParameters<F>,
+	// 	params3: PoseidonParameters<F>,
+	// 	params4: PoseidonParameters<F>,
+	// 	params5: PoseidonParameters<F>,
+	// }
+
+	// impl<F, P, HG, const N: usize, const M: usize, const INS: usize, const OUTS:
+	// usize> 	VariableAnchorPoseidonSetup<F, P>
+	// where
+	// 	F: PrimeField,
+	// 	P: TEModelParameters<BaseField = F>,
+	// 	HG: FieldHasherGadget<F, P>,
+	// {
+	// 	pub fn setup_circuit(
+	// 		self,
+	// 		public_amount: F,
+	// 		public_chain_id: F,
+	// 		// Input transactions
+	// 		in_amounts: [F; INS],
+	// 		in_blindings: [F; INS],
+	// 		in_nullifier_hashes: [F; INS], // Public
+	// 		in_private_keys: [F; INS],
+	// 		in_paths: [Path<F, HG::Native, N>; INS],
+	// 		in_indices: [F; INS],
+	// 		in_root_set: [F; M],
+	// 		// Output transactions
+	// 		out_amounts: [F; OUTS],
+	// 		out_blindings: [F; OUTS],
+	// 		out_chain_ids: [F; OUTS],
+	// 		out_public_keys: [F; OUTS],
+	// 		out_commitments: [F; OUTS], // Public
+
+	// 		// Arbitrary data to be added to the transcript
+	// 		arbitrary_data: F, // Public
+	// 	) -> VariableAnchorCircuit<F, P, HG, N, M, INS, OUTS> {
+
+	// 		VariableAnchorCircuit::new(
+	// 			public_amount,
+	// 			public_chain_id,
+	// 			in_amounts,
+	// 			in_blindings,
+	// 			in_nullifier_hashes,
+	// 			in_private_keys,
+	// 			in_paths, in_indices,
+	// 			in_root_set,
+	// 			out_amounts,
+	// 			out_blindings,
+	// 			out_chain_ids,
+	// 			out_public_keys,
+	// 			out_commitments,
+	// 			arbitrary_data,
+	// 			public_key_hasher,
+	// 			tree_hasher,
+	// 			signature_hasher,
+	// 			leaf_hasher)
+	// 	}
+	// }
 	#[test]
-	fn should_verify_correct_anchor_plonk() {
+	fn should_verify_correct_vanchor_plonk() {
 		let rng = &mut test_rng();
 		let curve = Curve::Bn254;
 
-		let params = setup_params_x5_3(curve);
-		let poseidon_native = PoseidonBn254 { params };
+		// Create Poseidon native hash functions of each width (this could be
+		// encapsulated by a helper)
+		let params2 = setup_params_x5_2::<Fq>(curve);
+		let poseidon_native2 = PoseidonBn254 { params: params2 };
+		let params3 = setup_params_x5_3::<Fq>(curve);
+		let poseidon_native3 = PoseidonBn254 { params: params3 };
+		let params4 = setup_params_x5_4::<Fq>(curve);
+		let poseidon_native4 = PoseidonBn254 { params: params4 };
+		let params5 = setup_params_x5_5::<Fq>(curve);
+		let poseidon_native5 = PoseidonBn254 { params: params5 };
 
-		// Randomly generated secrets
-		let secret = Fq::rand(rng);
-		let nullifier = Fq::rand(rng);
-
-		// Public data
-		let chain_id = Fq::from(1u32);
+		// Randomly generated public inputs
+		let public_amount = Fq::rand(rng);
+		let public_chain_id = Fq::rand(rng);
 		let arbitrary_data = Fq::rand(rng);
-		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
-		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
 
-		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
-		// scalars, then add leaf_hash as the final leaf
-		const HEIGHT: usize = 6usize;
-		let last_index = 1 << (HEIGHT - 1) - 1;
-		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
-		for i in 0..last_index {
-			leaves[i] = Fq::rand(rng);
-		}
-		leaves[last_index] = leaf_hash;
-		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
-			&leaves,
-			&poseidon_native,
-			&[0u8; 32],
-		)
-		.unwrap();
+		// Randomly generated private inputs
+		// Initialize arrays
+		let mut in_private_keys = [Fq::from(0u64); INS];
+		let mut in_blindings = [Fq::from(0u64); INS];
+		let mut in_amounts = [Fq::from(0u64); INS];
+		let mut in_nullifier_hashes = [Fq::from(0u64); INS];
 
-		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-		roots[0] = tree.root();
-
-		// Path
-		let path = tree.generate_membership_proof(last_index as u64);
-
-		// Create VariableAnchorCircuit
-		let mut anchor = VariableAnchorCircuit::<
-			Bn254Fr,
-			JubjubParameters,
-			PoseidonGadget,
-			HEIGHT,
-			BRIDGE_SIZE,
-			INS,
-			OUTS,
-		>::new(
-			chain_id,
-			secret,
-			nullifier,
-			nullifier_hash,
-			path,
-			roots,
-			arbitrary_data,
-			poseidon_native,
-		);
-
-		let res = gadget_tester::<Bn254, JubjubParameters, _>(&mut anchor, 1 << 17);
-		assert!(res.is_ok(), "{:?}", res.err().unwrap());
-	}
-
-	#[test]
-	fn should_fail_with_invalid_root_plonk() {
-		let rng = &mut test_rng();
-		let curve = Curve::Bn254;
-
-		let params = setup_params_x5_3(curve);
-		let poseidon_native = PoseidonBn254 { params };
-
-		// Randomly generated secrets
-		let secret = Fq::rand(rng);
-		let nullifier = Fq::rand(rng);
-
-		// Public data
-		let chain_id = Fq::from(1u32);
-		let arbitrary_data = Fq::rand(rng);
-		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
-		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
-
-		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
-		// scalars, then add leaf_hash as the final leaf
-		const HEIGHT: usize = 6usize;
-		let last_index = 1 << (HEIGHT - 1) - 1;
-		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
-		for i in 0..last_index {
-			leaves[i] = Fq::rand(rng);
-		}
-		leaves[last_index] = leaf_hash;
-		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
-			&leaves,
-			&poseidon_native,
-			&[0u8; 32],
-		)
-		.unwrap();
-		let mut root = tree.root();
-		let bad_root = root.double();
-		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-		roots[0] = bad_root;
-
-		// Path
-		let path = tree.generate_membership_proof(last_index as u64);
-
-		// Create VariableAnchorCircuit
-		let mut anchor = VariableAnchorCircuit::<
-			Bn254Fr,
-			JubjubParameters,
-			PoseidonGadget,
-			HEIGHT,
-			BRIDGE_SIZE,
-			INS,
-			OUTS,
-		>::new(
-			chain_id,
-			secret,
-			nullifier,
-			nullifier_hash,
-			path,
-			roots,
-			arbitrary_data,
-			poseidon_native,
-		);
-
-		// Fill a composer to extract the public_inputs
-		let mut composer = StandardComposer::<Bn254Fr, JubjubParameters>::new();
-		let _ = anchor.gadget(&mut composer);
-		let public_inputs = composer.construct_dense_pi_vec();
-
-		// Go through proof generation/verification
-		let u_params: UniversalParams<Bn254> =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
-		let proof = {
-			// Create a prover struct
-			let mut prover = Prover::<
-				Bn254,
-				JubjubParameters,
-				SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
-			>::new(b"vanchor");
-			prover.key_transcript(b"key", b"additional seed information");
-			// Add gadgets
-			let _ = anchor.gadget(prover.mut_cs());
-			// Commit Key (being lazy with error)
-			let (ck, _) =
-				SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-					.unwrap();
-			// Preprocess circuit
-			let _ = prover.preprocess(&ck.powers());
-			// Compute Proof
-			prover.prove(&ck.powers()).unwrap()
+		// I don't like this default path thing -- how can I initalize the in_paths
+		// array?
+		let default_path = Path::<Fq, PoseidonBn254, TREE_HEIGHT> {
+			path: [(Fq::from(0u64), Fq::from(0u64)); TREE_HEIGHT],
+			_marker: PhantomData,
 		};
+		let mut in_paths = [default_path; INS];
+		// let mut in_paths_vec: Vec<Path::<Fq, PoseidonBn254, TREE_HEIGHT>>;
+		// We'll say the index of each input is index:
+		let index = 0u64;
+		let in_indices = [Fq::from(index); INS];
+		// Populate with random numbers
+		for i in 0..INS {
+			in_private_keys[i] = Fq::rand(rng);
+			in_blindings[i] = Fq::rand(rng);
+			// TODO: Enforce range check on input amounts
+			in_amounts[i] = Fq::rand(rng);
 
-		// Verifier's view
-
-		// Create a Verifier object
-		let mut verifier = Verifier::new(b"vanchor");
-		verifier.key_transcript(b"key", b"additional seed information");
-		// Add gadgets
-		let _ = anchor.gadget(verifier.mut_cs());
-		// Compute Commit and Verifier key
-		let (ck, vk) =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
+			// Calculate what the input nullifier hashes would be based on these:
+			let public_key = poseidon_native2.hash(&in_private_keys[i..i + 1]).unwrap();
+			let leaf = poseidon_native5
+				.hash(&[public_chain_id, in_amounts[i], public_key, in_blindings[i]])
 				.unwrap();
-		// Preprocess circuit
-		verifier.preprocess(&ck.powers()).unwrap();
-
-		// Verify proof
-		let res = verifier.verify(&proof, &vk, &public_inputs).unwrap_err();
-		match res {
-			Error::ProofVerificationError => (),
-			err => panic!("Unexpected error: {:?}", err),
-		};
-	}
-
-	#[test]
-	fn should_fail_with_wrong_secret_plonk() {
-		let rng = &mut test_rng();
-		let curve = Curve::Bn254;
-
-		let params = setup_params_x5_3(curve);
-		let poseidon_native = PoseidonBn254 { params };
-
-		// Randomly generated secrets
-		let secret = Fq::rand(rng);
-		let nullifier = Fq::rand(rng);
-
-		// Public data
-		let chain_id = Fq::from(1u32);
-		let arbitrary_data = Fq::rand(rng);
-		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
-		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
-
-		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
-		// scalars, then add leaf_hash as the final leaf
-		const HEIGHT: usize = 6usize;
-		let last_index = 1 << (HEIGHT - 1) - 1;
-		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
-		for i in 0..last_index {
-			leaves[i] = Fq::rand(rng);
-		}
-		leaves[last_index] = leaf_hash;
-		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
-			&leaves,
-			&poseidon_native,
-			&[0u8; 32],
-		)
-		.unwrap();
-		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-		roots[0] = tree.root();
-		// Path
-		let path = tree.generate_membership_proof(last_index as u64);
-
-		// An incorrect secret value to use below
-		let bad_secret = secret.double();
-
-		// Create VariableAnchorCircuit
-		let mut anchor = VariableAnchorCircuit::<
-			Bn254Fr,
-			JubjubParameters,
-			PoseidonGadget,
-			HEIGHT,
-			BRIDGE_SIZE,
-			INS,
-			OUTS,
-		>::new(
-			chain_id,
-			bad_secret,
-			nullifier,
-			nullifier_hash,
-			path,
-			roots,
-			arbitrary_data,
-			poseidon_native,
-		);
-
-		// Fill a composer to extract the public_inputs
-		let mut composer = StandardComposer::<Bn254Fr, JubjubParameters>::new();
-		let _ = anchor.gadget(&mut composer);
-		let public_inputs = composer.construct_dense_pi_vec();
-
-		// Go through proof generation/verification
-		let u_params: UniversalParams<Bn254Fr> =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
-		let proof = {
-			// Create a prover struct
-			let mut prover = Prover::<
-				Bn254,
-				JubjubParameters,
-				SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
-			>::new(b"vanchor");
-			prover.key_transcript(b"key", b"additional seed information");
-			// Add gadgets
-			let _ = anchor.gadget(prover.mut_cs());
-			// Commit Key (being lazy with error)
-			let (ck, _) =
-				SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-					.unwrap();
-			// Preprocess circuit
-			let _ = prover.preprocess(&ck.powers());
-			// Compute Proof
-			prover.prove(&ck.powers()).unwrap()
-		};
-
-		// Verifier's view
-
-		// Create a Verifier object
-		let mut verifier = Verifier::new(b"vanchor");
-		verifier.key_transcript(b"key", b"additional seed information");
-		// Add gadgets
-		let _ = anchor.gadget(verifier.mut_cs());
-		// Compute Commit and Verifier key
-		let (ck, vk) =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
+			let signature = poseidon_native4
+				.hash(&[in_private_keys[i], leaf, in_indices[i]])
 				.unwrap();
-		// Preprocess circuit
-		verifier.preprocess(&ck.powers()).unwrap();
-
-		// Verify proof
-		let mut vk_bytes = Vec::new();
-		sonic_pc::VerifierKey::<Bn254Fr>::serialize(&vk, &mut vk_bytes).unwrap();
-		let kzg_vk = kzg10::VerifierKey::<Bn254Fr>::deserialize(&vk_bytes[..]).unwrap();
-		let res = verifier
-			.verify(&proof, &kzg_vk, &public_inputs)
-			.unwrap_err();
-		match res {
-			Error::ProofVerificationError => (),
-			err => panic!("Unexpected error: {:?}", err),
-		};
-	}
-
-	#[test]
-	fn should_fail_with_wrong_nullifier_plonk() {
-		let rng = &mut test_rng();
-		let curve = Curve::Bn254;
-
-		let params = setup_params_x5_3(curve);
-		let poseidon_native = PoseidonBn254 { params };
-
-		// Randomly generated secrets
-		let secret = Fq::rand(rng);
-		let nullifier = Fq::rand(rng);
-
-		// Public data
-		let chain_id = Fq::from(1u32);
-		let arbitrary_data = Fq::rand(rng);
-		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
-		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
-
-		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
-		// scalars, then add leaf_hash as the final leaf
-		const HEIGHT: usize = 6usize;
-		let last_index = 1 << (HEIGHT - 1) - 1;
-		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
-		for i in 0..last_index {
-			leaves[i] = Fq::rand(rng);
-		}
-		leaves[last_index] = leaf_hash;
-		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
-			&leaves,
-			&poseidon_native,
-			&[0u8; 32],
-		)
-		.unwrap();
-		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-		roots[0] = tree.root();
-
-		// Path
-		let path = tree.generate_membership_proof(last_index as u64);
-
-		// An incorrect secret value to use below
-		let bad_nullifier = nullifier.double();
-
-		// Create VariableAnchorCircuit
-		let mut anchor = VariableAnchorCircuit::<
-			Bn254Fr,
-			JubjubParameters,
-			PoseidonGadget,
-			HEIGHT,
-			BRIDGE_SIZE,
-			INS,
-			OUTS,
-		>::new(
-			chain_id,
-			secret,
-			bad_nullifier,
-			nullifier_hash,
-			path,
-			roots,
-			arbitrary_data,
-			poseidon_native,
-		);
-
-		// Fill a composer to extract the public_inputs
-		let mut composer = StandardComposer::<Bn254Fr, JubjubParameters>::new();
-		let _ = anchor.gadget(&mut composer);
-		let public_inputs = composer.construct_dense_pi_vec();
-
-		// Go through proof generation/verification
-		let u_params: UniversalParams<Bn254Fr> =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
-		let proof = {
-			// Create a prover struct
-			let mut prover = Prover::<
-				Bn254,
-				JubjubParameters,
-				SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
-			>::new(b"vanchor");
-			prover.key_transcript(b"key", b"additional seed information");
-			// Add gadgets
-			let _ = anchor.gadget(prover.mut_cs());
-			// Commit Key (being lazy with error)
-			let (ck, _) =
-				SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-					.unwrap();
-			// Preprocess circuit
-			let _ = prover.preprocess(&ck.powers());
-			// Compute Proof
-			prover.prove(&ck.powers()).unwrap()
-		};
-
-		// Verifier's view
-
-		// Create a Verifier object
-		let mut verifier = Verifier::new(b"vanchor");
-		verifier.key_transcript(b"key", b"additional seed information");
-		// Add gadgets
-		let _ = anchor.gadget(verifier.mut_cs());
-		// Compute Commit and Verifier key
-		let (ck, vk) =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
+			in_nullifier_hashes[i] = poseidon_native4
+				.hash(&[leaf, in_indices[i], signature])
 				.unwrap();
-		// Preprocess circuit
-		verifier.preprocess(&ck.powers()).unwrap();
 
-		// Verify proof
-		let mut vk_bytes = Vec::new();
-		sonic_pc::VerifierKey::<Bn254Fr>::serialize(&vk, &mut vk_bytes).unwrap();
-		let kzg_vk = kzg10::VerifierKey::<Bn254Fr>::deserialize(&vk_bytes[..]).unwrap();
-		let res = verifier
-			.verify(&proof, &kzg_vk, &public_inputs)
-			.unwrap_err();
-		match res {
-			Error::ProofVerificationError => (),
-			err => panic!("Unexpected error: {:?}", err),
-		};
-	}
-
-	#[test]
-	fn should_fail_with_wrong_path_plonk() {
-		let rng = &mut test_rng();
-		let curve = Curve::Bn254;
-
-		let params = setup_params_x5_3(curve);
-		let poseidon_native = PoseidonBn254 { params };
-
-		// Randomly generated secrets
-		let secret = Fq::rand(rng);
-		let nullifier = Fq::rand(rng);
-
-		// Public data
-		let chain_id = Fq::from(1u32);
-		let arbitrary_data = Fq::rand(rng);
-		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
-		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
-
-		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
-		// scalars, then add leaf_hash as the final leaf
-		const HEIGHT: usize = 6usize;
-		let last_index = 1 << (HEIGHT - 1) - 1;
-		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
-		for i in 0..last_index {
-			leaves[i] = Fq::rand(rng);
+			// Simulate a Merkle tree for each input
+			let default_leaf = [0u8; 32];
+			let merkle_tree = SparseMerkleTree::<Fq, PoseidonBn254, TREE_HEIGHT>::new_sequential(
+				&[leaf],
+				&poseidon_native3,
+				&default_leaf,
+			)
+			.unwrap();
+			in_paths[i] = merkle_tree.generate_membership_proof(index);
 		}
-		leaves[last_index] = leaf_hash;
-		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
-			&leaves,
-			&poseidon_native,
-			&[0u8; 32],
-		)
-		.unwrap();
-		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-		roots[0] = tree.root();
 
-		// An incorrect path to use below
-		let bad_path = tree.generate_membership_proof((last_index as u64) - 1);
+		// Output amounts cannot be randomly generated since they may then exceed input
+		// amount.
+		let mut out_amounts = [Fq::from(0u64); OUTS];
+		out_amounts[0] = in_amounts[0];
+		out_amounts[1] = public_amount + in_amounts[1];
 
-		// Create VariableAnchorCircuit
-		let mut anchor = VariableAnchorCircuit::<
-			Bn254Fr,
-			JubjubParameters,
-			PoseidonGadget,
-			HEIGHT,
-			BRIDGE_SIZE,
-			INS,
-			OUTS,
-		>::new(
-			chain_id,
-			secret,
-			nullifier,
-			nullifier_hash,
-			bad_path,
-			roots,
-			arbitrary_data,
-			poseidon_native,
-		);
-
-		// Fill a composer to extract the public_inputs
-		let mut composer = StandardComposer::<Bn254Fr, JubjubParameters>::new();
-		let _ = anchor.gadget(&mut composer);
-		let public_inputs = composer.construct_dense_pi_vec();
-
-		// Go through proof generation/verification
-		let u_params: UniversalParams<Bn254Fr> =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
-		let proof = {
-			// Create a prover struct
-			let mut prover = Prover::<
-				Bn254,
-				JubjubParameters,
-				SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
-			>::new(b"vanchor");
-			prover.key_transcript(b"key", b"additional seed information");
-			// Add gadgets
-			let _ = anchor.gadget(prover.mut_cs());
-			// Commit Key (being lazy with error)
-			let (ck, _) =
-				SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-					.unwrap();
-			// Preprocess circuit
-			let _ = prover.preprocess(&ck.powers());
-			// Compute Proof
-			prover.prove(&ck.powers()).unwrap()
-		};
-
-		// Verifier's view
-
-		// Create a Verifier object
-		let mut verifier = Verifier::new(b"vanchor");
-		verifier.key_transcript(b"key", b"additional seed information");
-		// Add gadgets
-		let _ = anchor.gadget(verifier.mut_cs());
-		// Compute Commit and Verifier key
-		let (ck, vk) =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-				.unwrap();
-		// Preprocess circuit
-		verifier.preprocess(&ck.powers()).unwrap();
-
-		// Verify proof
-		let mut vk_bytes = Vec::new();
-		sonic_pc::VerifierKey::<Bn254Fr>::serialize(&vk, &mut vk_bytes).unwrap();
-		let kzg_vk = kzg10::VerifierKey::<Bn254Fr>::deserialize(&vk_bytes[..]).unwrap();
-		let res = verifier
-			.verify(&proof, &kzg_vk, &public_inputs)
-			.unwrap_err();
-		match res {
-			Error::ProofVerificationError => (),
-			err => panic!("Unexpected error: {:?}", err),
-		};
-	}
-
-	#[test]
-	fn should_fail_with_wrong_nullifier_hash_plonk() {
-		let rng = &mut test_rng();
-		let curve = Curve::Bn254;
-
-		let params = setup_params_x5_3(curve);
-		let poseidon_native = PoseidonBn254 { params };
-
-		// Randomly generated secrets
-		let secret = Fq::rand(rng);
-		let nullifier = Fq::rand(rng);
-
-		// Public data
-		let chain_id = Fq::from(1u32);
-		let arbitrary_data = Fq::rand(rng);
-		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
-		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
-
-		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
-		// scalars, then add leaf_hash as the final leaf
-		const HEIGHT: usize = 6usize;
-		let last_index = 1 << (HEIGHT - 1) - 1;
-		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
-		for i in 0..last_index {
-			leaves[i] = Fq::rand(rng);
+		// Other output quantities can be randomly generated
+		let mut out_private_keys = [Fq::from(0u64); OUTS];
+		let mut out_public_keys = [Fq::from(0u64); OUTS];
+		let mut out_blindings = [Fq::from(0u64); OUTS];
+		let mut out_chain_ids = [Fq::from(0u64); OUTS];
+		for i in 0..OUTS {
+			out_blindings[i] = Fq::rand(rng);
+			out_private_keys[i] = Fq::rand(rng);
+			out_chain_ids[i] = Fq::rand(rng);
+			out_public_keys[i] = poseidon_native2.hash(&out_private_keys[i..i + 1]).unwrap();
 		}
-		leaves[last_index] = leaf_hash;
-		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
-			&leaves,
-			&poseidon_native,
-			&[0u8; 32],
-		)
-		.unwrap();
-		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-		roots[0] = tree.root();
 
-		// Path
-		let path = tree.generate_membership_proof(last_index as u64);
+		// // Public data
+		// let nullifier_hash = poseidon_native.hash_two(&nullifier,
+		// &nullifier).unwrap(); let leaf_hash =
+		// poseidon_native.hash_two(&secret, &nullifier).unwrap();
 
-		// Incorrect nullifier hash to use below
-		let bad_nullifier_hash = nullifier_hash.double();
+		// // Create a tree whose leaves are already populated with 2^HEIGHT - 1
+		// random // scalars, then add leaf_hash as the final leaf
+		// const HEIGHT: usize = 6usize;
+		// let last_index = 1 << (HEIGHT - 1) - 1;
+		// let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
+		// for i in 0..last_index {
+		// 	leaves[i] = Fq::rand(rng);
+		// }
+		// leaves[last_index] = leaf_hash;
+		// let tree = SparseMerkleTree::<Fq, PoseidonBn254,
+		// HEIGHT>::new_sequential( 	&leaves,
+		// 	&poseidon_native,
+		// 	&[0u8; 32],
+		// )
+		// .unwrap();
 
-		// Create VariableAnchorCircuit
-		let mut anchor = VariableAnchorCircuit::<
-			Bn254Fr,
-			JubjubParameters,
-			PoseidonGadget,
-			HEIGHT,
-			BRIDGE_SIZE,
-			INS,
-			OUTS,
-		>::new(
-			chain_id,
-			secret,
-			nullifier,
-			bad_nullifier_hash,
-			path,
-			roots,
-			arbitrary_data,
-			poseidon_native,
-		);
+		// let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+		// roots[0] = tree.root();
 
-		// Fill a composer to extract the public_inputs
-		let mut composer = StandardComposer::<Bn254Fr, JubjubParameters>::new();
-		let _ = anchor.gadget(&mut composer);
-		let public_inputs = composer.construct_dense_pi_vec();
+		// // Path
+		// let path = tree.generate_membership_proof(last_index as u64);
 
-		// Go through proof generation/verification
-		let u_params: UniversalParams<Bn254Fr> =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
-		let proof = {
-			// Create a prover struct
-			let mut prover = Prover::<
-				Bn254,
-				JubjubParameters,
-				SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
-			>::new(b"vanchor");
-			prover.key_transcript(b"key", b"additional seed information");
-			// Add gadgets
-			let _ = anchor.gadget(prover.mut_cs());
-			// Commit Key (being lazy with error)
-			let (ck, _) =
-				SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-					.unwrap();
-			// Preprocess circuit
-			let _ = prover.preprocess(&ck.powers());
-			// Compute Proof
-			prover.prove(&ck.powers()).unwrap()
-		};
+		// // Create VariableAnchorCircuit
+		// let mut anchor = VariableAnchorCircuit::<
+		// 	Bn254Fr,
+		// 	JubjubParameters,
+		// 	PoseidonGadget,
+		// 	HEIGHT,
+		// 	BRIDGE_SIZE,
+		// 	INS,
+		// 	OUTS,
+		// >::new(
+		// 	chain_id,
+		// 	secret,
+		// 	nullifier,
+		// 	nullifier_hash,
+		// 	path,
+		// 	roots,
+		// 	arbitrary_data,
+		// 	poseidon_native,
+		// );
 
-		// Verifier's view
-
-		// Create a Verifier object
-		let mut verifier = Verifier::new(b"vanchor");
-		verifier.key_transcript(b"key", b"additional seed information");
-		// Add gadgets
-		let _ = anchor.gadget(verifier.mut_cs());
-		// Compute Commit and Verifier key
-		let (ck, vk) =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-				.unwrap();
-		// Preprocess circuit
-		verifier.preprocess(&ck.powers()).unwrap();
-
-		// Verify proof
-		let mut vk_bytes = Vec::new();
-		sonic_pc::VerifierKey::<Bn254Fr>::serialize(&vk, &mut vk_bytes).unwrap();
-		let kzg_vk = kzg10::VerifierKey::<Bn254Fr>::deserialize(&vk_bytes[..]).unwrap();
-		let res = verifier
-			.verify(&proof, &kzg_vk, &public_inputs)
-			.unwrap_err();
-		match res {
-			Error::ProofVerificationError => (),
-			err => panic!("Unexpected error: {:?}", err),
-		};
+		// let res = gadget_tester::<Bn254, JubjubParameters, _>(&mut anchor, 1
+		// << 17); assert!(res.is_ok(), "{:?}", res.err().unwrap());
 	}
 
-	#[test]
-	fn should_fail_with_wrong_arbitrary_data_plonk() {
-		let rng = &mut test_rng();
-		let curve = Curve::Bn254;
+	// #[test]
+	// fn should_fail_with_invalid_root_plonk() {
+	// 	let rng = &mut test_rng();
+	// 	let curve = Curve::Bn254;
 
-		let params = setup_params_x5_3(curve);
-		let poseidon_native = PoseidonBn254 { params };
+	// 	let params = setup_params_x5_3(curve);
+	// 	let poseidon_native = PoseidonBn254 { params };
 
-		// Randomly generated secrets
-		let secret = Fq::rand(rng);
-		let nullifier = Fq::rand(rng);
+	// 	// Randomly generated secrets
+	// 	let secret = Fq::rand(rng);
+	// 	let nullifier = Fq::rand(rng);
 
-		// Public data
-		let chain_id = Fq::from(1u32);
-		let arbitrary_data = Fq::rand(rng);
-		let nullifier_hash = poseidon_native.hash_two(&nullifier, &nullifier).unwrap();
-		let leaf_hash = poseidon_native.hash_two(&secret, &nullifier).unwrap();
+	// 	// Public data
+	// 	let chain_id = Fq::from(1u32);
+	// 	let arbitrary_data = Fq::rand(rng);
+	// 	let nullifier_hash = poseidon_native.hash_two(&nullifier,
+	// &nullifier).unwrap(); 	let leaf_hash = poseidon_native.hash_two(&secret,
+	// &nullifier).unwrap();
 
-		// Create a tree whose leaves are already populated with 2^HEIGHT - 1 random
-		// scalars, then add leaf_hash as the final leaf
-		const HEIGHT: usize = 6usize;
-		let last_index = 1 << (HEIGHT - 1) - 1;
-		let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
-		for i in 0..last_index {
-			leaves[i] = Fq::rand(rng);
-		}
-		leaves[last_index] = leaf_hash;
-		let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
-			&leaves,
-			&poseidon_native,
-			&[0u8; 32],
-		)
-		.unwrap();
-		let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
-		roots[0] = tree.root();
+	// 	// Create a tree whose leaves are already populated with 2^HEIGHT - 1
+	// random 	// scalars, then add leaf_hash as the final leaf
+	// 	const HEIGHT: usize = 6usize;
+	// 	let last_index = 1 << (HEIGHT - 1) - 1;
+	// 	let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
+	// 	for i in 0..last_index {
+	// 		leaves[i] = Fq::rand(rng);
+	// 	}
+	// 	leaves[last_index] = leaf_hash;
+	// 	let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
+	// 		&leaves,
+	// 		&poseidon_native,
+	// 		&[0u8; 32],
+	// 	)
+	// 	.unwrap();
+	// 	let mut root = tree.root();
+	// 	let bad_root = root.double();
+	// 	let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+	// 	roots[0] = bad_root;
 
-		// Path
-		let path = tree.generate_membership_proof(last_index as u64);
+	// 	// Path
+	// 	let path = tree.generate_membership_proof(last_index as u64);
 
-		// Create VariableAnchorCircuit
-		let mut anchor = VariableAnchorCircuit::<
-			Bn254Fr,
-			JubjubParameters,
-			PoseidonGadget,
-			HEIGHT,
-			BRIDGE_SIZE,
-			INS,
-			OUTS,
-		>::new(
-			chain_id,
-			secret,
-			nullifier,
-			nullifier_hash,
-			path,
-			roots,
-			arbitrary_data,
-			poseidon_native,
-		);
+	// 	// Create VariableAnchorCircuit
+	// 	let mut anchor = VariableAnchorCircuit::<
+	// 		Bn254Fr,
+	// 		JubjubParameters,
+	// 		PoseidonGadget,
+	// 		HEIGHT,
+	// 		BRIDGE_SIZE,
+	// 		INS,
+	// 		OUTS,
+	// 	>::new(
+	// 		chain_id,
+	// 		secret,
+	// 		nullifier,
+	// 		nullifier_hash,
+	// 		path,
+	// 		roots,
+	// 		arbitrary_data,
+	// 		poseidon_native,
+	// 	);
 
-		// Fill a composer to extract the public_inputs
-		let mut composer = StandardComposer::<Bn254Fr, JubjubParameters>::new();
-		let _ = anchor.gadget(&mut composer);
-		let mut public_inputs = composer.construct_dense_pi_vec();
+	// 	// Fill a composer to extract the public_inputs
+	// 	let mut composer = StandardComposer::<Bn254Fr, JubjubParameters>::new();
+	// 	let _ = anchor.gadget(&mut composer);
+	// 	let public_inputs = composer.construct_dense_pi_vec();
 
-		// Go through proof generation/verification
-		let u_params: UniversalParams<Bn254Fr> =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
-		let proof = {
-			// Create a prover struct
-			let mut prover = Prover::<
-				Bn254,
-				JubjubParameters,
-				SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
-			>::new(b"vanchor");
-			prover.key_transcript(b"key", b"additional seed information");
-			// Add gadgets
-			let _ = anchor.gadget(prover.mut_cs());
-			// Commit Key (being lazy with error)
-			let (ck, _) =
-				SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-					.unwrap();
-			// Preprocess circuit
-			let _ = prover.preprocess(&ck.powers());
-			// Compute Proof
-			prover.prove(&ck.powers()).unwrap()
-		};
+	// 	// Go through proof generation/verification
+	// 	let u_params: UniversalParams<Bn254> =
+	// 		SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None,
+	// rng).unwrap(); 	let proof = {
+	// 		// Create a prover struct
+	// 		let mut prover = Prover::<
+	// 			Bn254,
+	// 			JubjubParameters,
+	// 			SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
+	// 		>::new(b"vanchor");
+	// 		prover.key_transcript(b"key", b"additional seed information");
+	// 		// Add gadgets
+	// 		let _ = anchor.gadget(prover.mut_cs());
+	// 		// Commit Key (being lazy with error)
+	// 		let (ck, _) =
+	// 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18,
+	// 0, None) 				.unwrap();
+	// 		// Preprocess circuit
+	// 		let _ = prover.preprocess(&ck.powers());
+	// 		// Compute Proof
+	// 		prover.prove(&ck.powers()).unwrap()
+	// 	};
 
-		// Verifier's view
+	// 	// Verifier's view
 
-		// Create a Verifier object
-		let mut verifier = Verifier::new(b"vanchor");
-		verifier.key_transcript(b"key", b"additional seed information");
-		// Add gadgets
-		let _ = anchor.gadget(verifier.mut_cs());
-		// Compute Commit and Verifier key
-		let (ck, vk) =
-			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18, 0, None)
-				.unwrap();
-		// Preprocess circuit
-		verifier.preprocess(&ck.powers()).unwrap();
+	// 	// Create a Verifier object
+	// 	let mut verifier = Verifier::new(b"vanchor");
+	// 	verifier.key_transcript(b"key", b"additional seed information");
+	// 	// Add gadgets
+	// 	let _ = anchor.gadget(verifier.mut_cs());
+	// 	// Compute Commit and Verifier key
+	// 	let (ck, vk) =
+	// 		SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18,
+	// 0, None) 			.unwrap();
+	// 	// Preprocess circuit
+	// 	verifier.preprocess(&ck.powers()).unwrap();
 
-		// The arbitrary data is stored at index 5 of the public input vector:
-		assert_eq!(arbitrary_data, public_inputs[7]);
-		// Modify the arbitrary data so that prover/verifier disagree
-		public_inputs[5].double_in_place();
+	// 	// Verify proof
+	// 	let res = verifier.verify(&proof, &vk, &public_inputs).unwrap_err();
+	// 	match res {
+	// 		Error::ProofVerificationError => (),
+	// 		err => panic!("Unexpected error: {:?}", err),
+	// 	};
+	// }
 
-		// Verify proof
-		let mut vk_bytes = Vec::new();
-		sonic_pc::VerifierKey::<Bn254Fr>::serialize(&vk, &mut vk_bytes).unwrap();
-		let kzg_vk = kzg10::VerifierKey::<Bn254Fr>::deserialize(&vk_bytes[..]).unwrap();
-		let res = verifier
-			.verify(&proof, &kzg_vk, &public_inputs)
-			.unwrap_err();
-		match res {
-			Error::ProofVerificationError => (),
-			err => panic!("Unexpected error: {:?}", err),
-		};
-	}
+	// #[test]
+	// fn should_fail_with_wrong_secret_plonk() {
+	// 	let rng = &mut test_rng();
+	// 	let curve = Curve::Bn254;
+
+	// 	let params = setup_params_x5_3(curve);
+	// 	let poseidon_native = PoseidonBn254 { params };
+
+	// 	// Randomly generated secrets
+	// 	let secret = Fq::rand(rng);
+	// 	let nullifier = Fq::rand(rng);
+
+	// 	// Public data
+	// 	let chain_id = Fq::from(1u32);
+	// 	let arbitrary_data = Fq::rand(rng);
+	// 	let nullifier_hash = poseidon_native.hash_two(&nullifier,
+	// &nullifier).unwrap(); 	let leaf_hash = poseidon_native.hash_two(&secret,
+	// &nullifier).unwrap();
+
+	// 	// Create a tree whose leaves are already populated with 2^HEIGHT - 1
+	// random 	// scalars, then add leaf_hash as the final leaf
+	// 	const HEIGHT: usize = 6usize;
+	// 	let last_index = 1 << (HEIGHT - 1) - 1;
+	// 	let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
+	// 	for i in 0..last_index {
+	// 		leaves[i] = Fq::rand(rng);
+	// 	}
+	// 	leaves[last_index] = leaf_hash;
+	// 	let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
+	// 		&leaves,
+	// 		&poseidon_native,
+	// 		&[0u8; 32],
+	// 	)
+	// 	.unwrap();
+	// 	let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+	// 	roots[0] = tree.root();
+	// 	// Path
+	// 	let path = tree.generate_membership_proof(last_index as u64);
+
+	// 	// An incorrect secret value to use below
+	// 	let bad_secret = secret.double();
+
+	// 	// Create VariableAnchorCircuit
+	// 	let mut anchor = VariableAnchorCircuit::<
+	// 		Bn254Fr,
+	// 		JubjubParameters,
+	// 		PoseidonGadget,
+	// 		HEIGHT,
+	// 		BRIDGE_SIZE,
+	// 		INS,
+	// 		OUTS,
+	// 	>::new(
+	// 		chain_id,
+	// 		bad_secret,
+	// 		nullifier,
+	// 		nullifier_hash,
+	// 		path,
+	// 		roots,
+	// 		arbitrary_data,
+	// 		poseidon_native,
+	// 	);
+
+	// 	// Fill a composer to extract the public_inputs
+	// 	let mut composer = StandardComposer::<Bn254Fr, JubjubParameters>::new();
+	// 	let _ = anchor.gadget(&mut composer);
+	// 	let public_inputs = composer.construct_dense_pi_vec();
+
+	// 	// Go through proof generation/verification
+	// 	let u_params: UniversalParams<Bn254Fr> =
+	// 		SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None,
+	// rng).unwrap(); 	let proof = {
+	// 		// Create a prover struct
+	// 		let mut prover = Prover::<
+	// 			Bn254,
+	// 			JubjubParameters,
+	// 			SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
+	// 		>::new(b"vanchor");
+	// 		prover.key_transcript(b"key", b"additional seed information");
+	// 		// Add gadgets
+	// 		let _ = anchor.gadget(prover.mut_cs());
+	// 		// Commit Key (being lazy with error)
+	// 		let (ck, _) =
+	// 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18,
+	// 0, None) 				.unwrap();
+	// 		// Preprocess circuit
+	// 		let _ = prover.preprocess(&ck.powers());
+	// 		// Compute Proof
+	// 		prover.prove(&ck.powers()).unwrap()
+	// 	};
+
+	// 	// Verifier's view
+
+	// 	// Create a Verifier object
+	// 	let mut verifier = Verifier::new(b"vanchor");
+	// 	verifier.key_transcript(b"key", b"additional seed information");
+	// 	// Add gadgets
+	// 	let _ = anchor.gadget(verifier.mut_cs());
+	// 	// Compute Commit and Verifier key
+	// 	let (ck, vk) =
+	// 		SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18,
+	// 0, None) 			.unwrap();
+	// 	// Preprocess circuit
+	// 	verifier.preprocess(&ck.powers()).unwrap();
+
+	// 	// Verify proof
+	// 	let mut vk_bytes = Vec::new();
+	// 	sonic_pc::VerifierKey::<Bn254Fr>::serialize(&vk, &mut vk_bytes).unwrap();
+	// 	let kzg_vk =
+	// kzg10::VerifierKey::<Bn254Fr>::deserialize(&vk_bytes[..]).unwrap();
+	// 	let res = verifier
+	// 		.verify(&proof, &kzg_vk, &public_inputs)
+	// 		.unwrap_err();
+	// 	match res {
+	// 		Error::ProofVerificationError => (),
+	// 		err => panic!("Unexpected error: {:?}", err),
+	// 	};
+	// }
+
+	// #[test]
+	// fn should_fail_with_wrong_nullifier_plonk() {
+	// 	let rng = &mut test_rng();
+	// 	let curve = Curve::Bn254;
+
+	// 	let params = setup_params_x5_3(curve);
+	// 	let poseidon_native = PoseidonBn254 { params };
+
+	// 	// Randomly generated secrets
+	// 	let secret = Fq::rand(rng);
+	// 	let nullifier = Fq::rand(rng);
+
+	// 	// Public data
+	// 	let chain_id = Fq::from(1u32);
+	// 	let arbitrary_data = Fq::rand(rng);
+	// 	let nullifier_hash = poseidon_native.hash_two(&nullifier,
+	// &nullifier).unwrap(); 	let leaf_hash = poseidon_native.hash_two(&secret,
+	// &nullifier).unwrap();
+
+	// 	// Create a tree whose leaves are already populated with 2^HEIGHT - 1
+	// random 	// scalars, then add leaf_hash as the final leaf
+	// 	const HEIGHT: usize = 6usize;
+	// 	let last_index = 1 << (HEIGHT - 1) - 1;
+	// 	let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
+	// 	for i in 0..last_index {
+	// 		leaves[i] = Fq::rand(rng);
+	// 	}
+	// 	leaves[last_index] = leaf_hash;
+	// 	let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
+	// 		&leaves,
+	// 		&poseidon_native,
+	// 		&[0u8; 32],
+	// 	)
+	// 	.unwrap();
+	// 	let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+	// 	roots[0] = tree.root();
+
+	// 	// Path
+	// 	let path = tree.generate_membership_proof(last_index as u64);
+
+	// 	// An incorrect secret value to use below
+	// 	let bad_nullifier = nullifier.double();
+
+	// 	// Create VariableAnchorCircuit
+	// 	let mut anchor = VariableAnchorCircuit::<
+	// 		Bn254Fr,
+	// 		JubjubParameters,
+	// 		PoseidonGadget,
+	// 		HEIGHT,
+	// 		BRIDGE_SIZE,
+	// 		INS,
+	// 		OUTS,
+	// 	>::new(
+	// 		chain_id,
+	// 		secret,
+	// 		bad_nullifier,
+	// 		nullifier_hash,
+	// 		path,
+	// 		roots,
+	// 		arbitrary_data,
+	// 		poseidon_native,
+	// 	);
+
+	// 	// Fill a composer to extract the public_inputs
+	// 	let mut composer = StandardComposer::<Bn254Fr, JubjubParameters>::new();
+	// 	let _ = anchor.gadget(&mut composer);
+	// 	let public_inputs = composer.construct_dense_pi_vec();
+
+	// 	// Go through proof generation/verification
+	// 	let u_params: UniversalParams<Bn254Fr> =
+	// 		SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None,
+	// rng).unwrap(); 	let proof = {
+	// 		// Create a prover struct
+	// 		let mut prover = Prover::<
+	// 			Bn254,
+	// 			JubjubParameters,
+	// 			SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
+	// 		>::new(b"vanchor");
+	// 		prover.key_transcript(b"key", b"additional seed information");
+	// 		// Add gadgets
+	// 		let _ = anchor.gadget(prover.mut_cs());
+	// 		// Commit Key (being lazy with error)
+	// 		let (ck, _) =
+	// 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18,
+	// 0, None) 				.unwrap();
+	// 		// Preprocess circuit
+	// 		let _ = prover.preprocess(&ck.powers());
+	// 		// Compute Proof
+	// 		prover.prove(&ck.powers()).unwrap()
+	// 	};
+
+	// 	// Verifier's view
+
+	// 	// Create a Verifier object
+	// 	let mut verifier = Verifier::new(b"vanchor");
+	// 	verifier.key_transcript(b"key", b"additional seed information");
+	// 	// Add gadgets
+	// 	let _ = anchor.gadget(verifier.mut_cs());
+	// 	// Compute Commit and Verifier key
+	// 	let (ck, vk) =
+	// 		SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18,
+	// 0, None) 			.unwrap();
+	// 	// Preprocess circuit
+	// 	verifier.preprocess(&ck.powers()).unwrap();
+
+	// 	// Verify proof
+	// 	let mut vk_bytes = Vec::new();
+	// 	sonic_pc::VerifierKey::<Bn254Fr>::serialize(&vk, &mut vk_bytes).unwrap();
+	// 	let kzg_vk =
+	// kzg10::VerifierKey::<Bn254Fr>::deserialize(&vk_bytes[..]).unwrap();
+	// 	let res = verifier
+	// 		.verify(&proof, &kzg_vk, &public_inputs)
+	// 		.unwrap_err();
+	// 	match res {
+	// 		Error::ProofVerificationError => (),
+	// 		err => panic!("Unexpected error: {:?}", err),
+	// 	};
+	// }
+
+	// #[test]
+	// fn should_fail_with_wrong_path_plonk() {
+	// 	let rng = &mut test_rng();
+	// 	let curve = Curve::Bn254;
+
+	// 	let params = setup_params_x5_3(curve);
+	// 	let poseidon_native = PoseidonBn254 { params };
+
+	// 	// Randomly generated secrets
+	// 	let secret = Fq::rand(rng);
+	// 	let nullifier = Fq::rand(rng);
+
+	// 	// Public data
+	// 	let chain_id = Fq::from(1u32);
+	// 	let arbitrary_data = Fq::rand(rng);
+	// 	let nullifier_hash = poseidon_native.hash_two(&nullifier,
+	// &nullifier).unwrap(); 	let leaf_hash = poseidon_native.hash_two(&secret,
+	// &nullifier).unwrap();
+
+	// 	// Create a tree whose leaves are already populated with 2^HEIGHT - 1
+	// random 	// scalars, then add leaf_hash as the final leaf
+	// 	const HEIGHT: usize = 6usize;
+	// 	let last_index = 1 << (HEIGHT - 1) - 1;
+	// 	let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
+	// 	for i in 0..last_index {
+	// 		leaves[i] = Fq::rand(rng);
+	// 	}
+	// 	leaves[last_index] = leaf_hash;
+	// 	let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
+	// 		&leaves,
+	// 		&poseidon_native,
+	// 		&[0u8; 32],
+	// 	)
+	// 	.unwrap();
+	// 	let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+	// 	roots[0] = tree.root();
+
+	// 	// An incorrect path to use below
+	// 	let bad_path = tree.generate_membership_proof((last_index as u64) - 1);
+
+	// 	// Create VariableAnchorCircuit
+	// 	let mut anchor = VariableAnchorCircuit::<
+	// 		Bn254Fr,
+	// 		JubjubParameters,
+	// 		PoseidonGadget,
+	// 		HEIGHT,
+	// 		BRIDGE_SIZE,
+	// 		INS,
+	// 		OUTS,
+	// 	>::new(
+	// 		chain_id,
+	// 		secret,
+	// 		nullifier,
+	// 		nullifier_hash,
+	// 		bad_path,
+	// 		roots,
+	// 		arbitrary_data,
+	// 		poseidon_native,
+	// 	);
+
+	// 	// Fill a composer to extract the public_inputs
+	// 	let mut composer = StandardComposer::<Bn254Fr, JubjubParameters>::new();
+	// 	let _ = anchor.gadget(&mut composer);
+	// 	let public_inputs = composer.construct_dense_pi_vec();
+
+	// 	// Go through proof generation/verification
+	// 	let u_params: UniversalParams<Bn254Fr> =
+	// 		SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None,
+	// rng).unwrap(); 	let proof = {
+	// 		// Create a prover struct
+	// 		let mut prover = Prover::<
+	// 			Bn254,
+	// 			JubjubParameters,
+	// 			SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
+	// 		>::new(b"vanchor");
+	// 		prover.key_transcript(b"key", b"additional seed information");
+	// 		// Add gadgets
+	// 		let _ = anchor.gadget(prover.mut_cs());
+	// 		// Commit Key (being lazy with error)
+	// 		let (ck, _) =
+	// 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18,
+	// 0, None) 				.unwrap();
+	// 		// Preprocess circuit
+	// 		let _ = prover.preprocess(&ck.powers());
+	// 		// Compute Proof
+	// 		prover.prove(&ck.powers()).unwrap()
+	// 	};
+
+	// 	// Verifier's view
+
+	// 	// Create a Verifier object
+	// 	let mut verifier = Verifier::new(b"vanchor");
+	// 	verifier.key_transcript(b"key", b"additional seed information");
+	// 	// Add gadgets
+	// 	let _ = anchor.gadget(verifier.mut_cs());
+	// 	// Compute Commit and Verifier key
+	// 	let (ck, vk) =
+	// 		SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18,
+	// 0, None) 			.unwrap();
+	// 	// Preprocess circuit
+	// 	verifier.preprocess(&ck.powers()).unwrap();
+
+	// 	// Verify proof
+	// 	let mut vk_bytes = Vec::new();
+	// 	sonic_pc::VerifierKey::<Bn254Fr>::serialize(&vk, &mut vk_bytes).unwrap();
+	// 	let kzg_vk =
+	// kzg10::VerifierKey::<Bn254Fr>::deserialize(&vk_bytes[..]).unwrap();
+	// 	let res = verifier
+	// 		.verify(&proof, &kzg_vk, &public_inputs)
+	// 		.unwrap_err();
+	// 	match res {
+	// 		Error::ProofVerificationError => (),
+	// 		err => panic!("Unexpected error: {:?}", err),
+	// 	};
+	// }
+
+	// #[test]
+	// fn should_fail_with_wrong_nullifier_hash_plonk() {
+	// 	let rng = &mut test_rng();
+	// 	let curve = Curve::Bn254;
+
+	// 	let params = setup_params_x5_3(curve);
+	// 	let poseidon_native = PoseidonBn254 { params };
+
+	// 	// Randomly generated secrets
+	// 	let secret = Fq::rand(rng);
+	// 	let nullifier = Fq::rand(rng);
+
+	// 	// Public data
+	// 	let chain_id = Fq::from(1u32);
+	// 	let arbitrary_data = Fq::rand(rng);
+	// 	let nullifier_hash = poseidon_native.hash_two(&nullifier,
+	// &nullifier).unwrap(); 	let leaf_hash = poseidon_native.hash_two(&secret,
+	// &nullifier).unwrap();
+
+	// 	// Create a tree whose leaves are already populated with 2^HEIGHT - 1
+	// random 	// scalars, then add leaf_hash as the final leaf
+	// 	const HEIGHT: usize = 6usize;
+	// 	let last_index = 1 << (HEIGHT - 1) - 1;
+	// 	let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
+	// 	for i in 0..last_index {
+	// 		leaves[i] = Fq::rand(rng);
+	// 	}
+	// 	leaves[last_index] = leaf_hash;
+	// 	let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
+	// 		&leaves,
+	// 		&poseidon_native,
+	// 		&[0u8; 32],
+	// 	)
+	// 	.unwrap();
+	// 	let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+	// 	roots[0] = tree.root();
+
+	// 	// Path
+	// 	let path = tree.generate_membership_proof(last_index as u64);
+
+	// 	// Incorrect nullifier hash to use below
+	// 	let bad_nullifier_hash = nullifier_hash.double();
+
+	// 	// Create VariableAnchorCircuit
+	// 	let mut anchor = VariableAnchorCircuit::<
+	// 		Bn254Fr,
+	// 		JubjubParameters,
+	// 		PoseidonGadget,
+	// 		HEIGHT,
+	// 		BRIDGE_SIZE,
+	// 		INS,
+	// 		OUTS,
+	// 	>::new(
+	// 		chain_id,
+	// 		secret,
+	// 		nullifier,
+	// 		bad_nullifier_hash,
+	// 		path,
+	// 		roots,
+	// 		arbitrary_data,
+	// 		poseidon_native,
+	// 	);
+
+	// 	// Fill a composer to extract the public_inputs
+	// 	let mut composer = StandardComposer::<Bn254Fr, JubjubParameters>::new();
+	// 	let _ = anchor.gadget(&mut composer);
+	// 	let public_inputs = composer.construct_dense_pi_vec();
+
+	// 	// Go through proof generation/verification
+	// 	let u_params: UniversalParams<Bn254Fr> =
+	// 		SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None,
+	// rng).unwrap(); 	let proof = {
+	// 		// Create a prover struct
+	// 		let mut prover = Prover::<
+	// 			Bn254,
+	// 			JubjubParameters,
+	// 			SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
+	// 		>::new(b"vanchor");
+	// 		prover.key_transcript(b"key", b"additional seed information");
+	// 		// Add gadgets
+	// 		let _ = anchor.gadget(prover.mut_cs());
+	// 		// Commit Key (being lazy with error)
+	// 		let (ck, _) =
+	// 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18,
+	// 0, None) 				.unwrap();
+	// 		// Preprocess circuit
+	// 		let _ = prover.preprocess(&ck.powers());
+	// 		// Compute Proof
+	// 		prover.prove(&ck.powers()).unwrap()
+	// 	};
+
+	// 	// Verifier's view
+
+	// 	// Create a Verifier object
+	// 	let mut verifier = Verifier::new(b"vanchor");
+	// 	verifier.key_transcript(b"key", b"additional seed information");
+	// 	// Add gadgets
+	// 	let _ = anchor.gadget(verifier.mut_cs());
+	// 	// Compute Commit and Verifier key
+	// 	let (ck, vk) =
+	// 		SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18,
+	// 0, None) 			.unwrap();
+	// 	// Preprocess circuit
+	// 	verifier.preprocess(&ck.powers()).unwrap();
+
+	// 	// Verify proof
+	// 	let mut vk_bytes = Vec::new();
+	// 	sonic_pc::VerifierKey::<Bn254Fr>::serialize(&vk, &mut vk_bytes).unwrap();
+	// 	let kzg_vk =
+	// kzg10::VerifierKey::<Bn254Fr>::deserialize(&vk_bytes[..]).unwrap();
+	// 	let res = verifier
+	// 		.verify(&proof, &kzg_vk, &public_inputs)
+	// 		.unwrap_err();
+	// 	match res {
+	// 		Error::ProofVerificationError => (),
+	// 		err => panic!("Unexpected error: {:?}", err),
+	// 	};
+	// }
+
+	// #[test]
+	// fn should_fail_with_wrong_arbitrary_data_plonk() {
+	// 	let rng = &mut test_rng();
+	// 	let curve = Curve::Bn254;
+
+	// 	let params = setup_params_x5_3(curve);
+	// 	let poseidon_native = PoseidonBn254 { params };
+
+	// 	// Randomly generated secrets
+	// 	let secret = Fq::rand(rng);
+	// 	let nullifier = Fq::rand(rng);
+
+	// 	// Public data
+	// 	let chain_id = Fq::from(1u32);
+	// 	let arbitrary_data = Fq::rand(rng);
+	// 	let nullifier_hash = poseidon_native.hash_two(&nullifier,
+	// &nullifier).unwrap(); 	let leaf_hash = poseidon_native.hash_two(&secret,
+	// &nullifier).unwrap();
+
+	// 	// Create a tree whose leaves are already populated with 2^HEIGHT - 1
+	// random 	// scalars, then add leaf_hash as the final leaf
+	// 	const HEIGHT: usize = 6usize;
+	// 	let last_index = 1 << (HEIGHT - 1) - 1;
+	// 	let mut leaves = [Fq::from(0u8); 1 << (HEIGHT - 1)];
+	// 	for i in 0..last_index {
+	// 		leaves[i] = Fq::rand(rng);
+	// 	}
+	// 	leaves[last_index] = leaf_hash;
+	// 	let tree = SparseMerkleTree::<Fq, PoseidonBn254, HEIGHT>::new_sequential(
+	// 		&leaves,
+	// 		&poseidon_native,
+	// 		&[0u8; 32],
+	// 	)
+	// 	.unwrap();
+	// 	let mut roots = [Fq::from(0u8); BRIDGE_SIZE];
+	// 	roots[0] = tree.root();
+
+	// 	// Path
+	// 	let path = tree.generate_membership_proof(last_index as u64);
+
+	// 	// Create VariableAnchorCircuit
+	// 	let mut anchor = VariableAnchorCircuit::<
+	// 		Bn254Fr,
+	// 		JubjubParameters,
+	// 		PoseidonGadget,
+	// 		HEIGHT,
+	// 		BRIDGE_SIZE,
+	// 		INS,
+	// 		OUTS,
+	// 	>::new(
+	// 		chain_id,
+	// 		secret,
+	// 		nullifier,
+	// 		nullifier_hash,
+	// 		path,
+	// 		roots,
+	// 		arbitrary_data,
+	// 		poseidon_native,
+	// 	);
+
+	// 	// Fill a composer to extract the public_inputs
+	// 	let mut composer = StandardComposer::<Bn254Fr, JubjubParameters>::new();
+	// 	let _ = anchor.gadget(&mut composer);
+	// 	let mut public_inputs = composer.construct_dense_pi_vec();
+
+	// 	// Go through proof generation/verification
+	// 	let u_params: UniversalParams<Bn254Fr> =
+	// 		SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None,
+	// rng).unwrap(); 	let proof = {
+	// 		// Create a prover struct
+	// 		let mut prover = Prover::<
+	// 			Bn254,
+	// 			JubjubParameters,
+	// 			SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
+	// 		>::new(b"vanchor");
+	// 		prover.key_transcript(b"key", b"additional seed information");
+	// 		// Add gadgets
+	// 		let _ = anchor.gadget(prover.mut_cs());
+	// 		// Commit Key (being lazy with error)
+	// 		let (ck, _) =
+	// 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18,
+	// 0, None) 				.unwrap();
+	// 		// Preprocess circuit
+	// 		let _ = prover.preprocess(&ck.powers());
+	// 		// Compute Proof
+	// 		prover.prove(&ck.powers()).unwrap()
+	// 	};
+
+	// 	// Verifier's view
+
+	// 	// Create a Verifier object
+	// 	let mut verifier = Verifier::new(b"vanchor");
+	// 	verifier.key_transcript(b"key", b"additional seed information");
+	// 	// Add gadgets
+	// 	let _ = anchor.gadget(verifier.mut_cs());
+	// 	// Compute Commit and Verifier key
+	// 	let (ck, vk) =
+	// 		SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::trim(&u_params, 1 << 18,
+	// 0, None) 			.unwrap();
+	// 	// Preprocess circuit
+	// 	verifier.preprocess(&ck.powers()).unwrap();
+
+	// 	// The arbitrary data is stored at index 5 of the public input vector:
+	// 	assert_eq!(arbitrary_data, public_inputs[7]);
+	// 	// Modify the arbitrary data so that prover/verifier disagree
+	// 	public_inputs[5].double_in_place();
+
+	// 	// Verify proof
+	// 	let mut vk_bytes = Vec::new();
+	// 	sonic_pc::VerifierKey::<Bn254Fr>::serialize(&vk, &mut vk_bytes).unwrap();
+	// 	let kzg_vk =
+	// kzg10::VerifierKey::<Bn254Fr>::deserialize(&vk_bytes[..]).unwrap();
+	// 	let res = verifier
+	// 		.verify(&proof, &kzg_vk, &public_inputs)
+	// 		.unwrap_err();
+	// 	match res {
+	// 		Error::ProofVerificationError => (),
+	// 		err => panic!("Unexpected error: {:?}", err),
+	// 	};
+	// }
 }

--- a/arkworks-plonk-circuits/src/vanchor/mod.rs
+++ b/arkworks-plonk-circuits/src/vanchor/mod.rs
@@ -3,9 +3,9 @@
 // in the pool and join them together, split them, and any combination
 // of the two.
 
-// The inputs to the VAnchor are unspent outputs we want to spend (we are spending the inputs),
-// and we create outputs which are new, unspent UTXOs. We create commitments
-// for each output and these are inserted into merkle trees.
+// The inputs to the VAnchor are unspent outputs we want to spend (we are
+// spending the inputs), and we create outputs which are new, unspent UTXOs. We
+// create commitments for each output and these are inserted into merkle trees.
 
 // The VAnchor is also a bridged system. It takes as a public input
 // a set of merkle roots that it will use to verify the membership
@@ -19,30 +19,32 @@
 use std::ops::Add;
 
 use crate::{
-	merkle_tree::{PatHadget, PathGadget}, vanchor::add_public_input_variable,
-	poseidon::poseidon::FieldHasherGadget, set_membership::check_set_membership, mixer::add_public_input_variable,
+	merkle_tree::{PatHadget, PathGadget},
+	mixer::add_public_input_variable,
+	poseidon::poseidon::FieldHasherGadget,
+	set_membership::check_set_membership,
+	vanchor::add_public_input_variable,
 };
 use ark_ec::{models::TEModelParameters, PairingEngine};
 use ark_ff::PrimeField;
 use ark_std::{One, Zero};
-use arkworks_gadgets::merkle_tree::simple_merkle::Path;
+use arkworks_gadgets::{merkle_tree::simple_merkle::Path, poseidon::field_hasher::FieldHasher};
 use plonk_core::{
 	circuit::Circuit, constraint_system::StandardComposer, error::Error, prelude::Variable,
 };
-use arkworks_gadgets::poseidon::field_hasher::FieldHasher;
 
 pub struct VariableAnchorCircuit<
 	F: PrimeField,
 	P: TEModelParameters<BaseField = F>,
 	HG: FieldHasherGadget<F, P>,
-    // Tree height
+	// Tree height
 	const N: usize,
-    // Size of the root set (bridge length)
+	// Size of the root set (bridge length)
 	const M: usize,
-    // Number of inputs
-    const INS: usize,
-    // Number of outputs
-    const OUTS: usize,
+	// Number of inputs
+	const INS: usize,
+	// Number of outputs
+	const OUTS: usize,
 > {
 	// chain_id: F,
 	// secret: F,
@@ -53,97 +55,99 @@ pub struct VariableAnchorCircuit<
 	// arbitrary_data: F,
 	// hasher: H::Native,
 
-    // INS = number of input transactions
-    // OUTS = number of output transactions
-    // N = Tree height
-    // M = Size of the root set
+	// INS = number of input transactions
+	// OUTS = number of output transactions
+	// N = Tree height
+	// M = Size of the root set
 
-    // sum of input amounts + public amount == sum of output amounts
-    public_amount: F, // Public
-    public_chain_id: F, // Public
+	// sum of input amounts + public amount == sum of output amounts
+	public_amount: F,   // Public
+	public_chain_id: F, // Public
 
-    // Input transactions
-    in_amounts: [F; INS],
-    in_blindings: [F; INS],
-    in_nullifier_hashes: [F; INS], // Public
-    in_private_keys: [F; INS],
-    in_paths: [Path<F, HG::Native, N>; INS],
-    in_indices: [F; INS],
-    in_root_set: [F; M],
+	// Input transactions
+	in_amounts: [F; INS],
+	in_blindings: [F; INS],
+	in_nullifier_hashes: [F; INS], // Public
+	in_private_keys: [F; INS],
+	in_paths: [Path<F, HG::Native, N>; INS],
+	in_indices: [F; INS],
+	in_root_set: [F; M],
 
-    // Output transactions 
-    out_amounts: [F; OUTS],
-    out_blindings: [F; OUTS],
-    out_chain_ids: [F; OUTS],
-    out_public_keys: [F; OUTS],
-    out_commitments: [F; OUTS], // Public
+	// Output transactions
+	out_amounts: [F; OUTS],
+	out_blindings: [F; OUTS],
+	out_chain_ids: [F; OUTS],
+	out_public_keys: [F; OUTS],
+	out_commitments: [F; OUTS], // Public
 
-    // Arbitrary data to be added to the transcript
-    arbitrary_data: F, // Public
+	// Arbitrary data to be added to the transcript
+	arbitrary_data: F, // Public
 
-    // All the hashers used in this circuit
-    // Used for hashing private_key -- width 2
-    public_key_hasher: HG::Native,
-    // Used for hashing nodes in the tree -- width 3
-    tree_hasher: HG::Native,
-    // Used for creating leaf signature and the nullifier hash -- width 4
-    signature_hasher: HG::Native,
-    // Used for creating leaf -- width 5
-    leaf_hasher: HG::Native
+	// All the hashers used in this circuit
+	// Used for hashing private_key -- width 2
+	public_key_hasher: HG::Native,
+	// Used for hashing nodes in the tree -- width 3
+	tree_hasher: HG::Native,
+	// Used for creating leaf signature and the nullifier hash -- width 4
+	signature_hasher: HG::Native,
+	// Used for creating leaf -- width 5
+	leaf_hasher: HG::Native,
 }
 
-impl<F, P, HG, const N: usize, const M: usize, const INS: usize, const OUTS: usize> VariableAnchorCircuit<F, P, HG, N, M, INS, OUTS>
+impl<F, P, HG, const N: usize, const M: usize, const INS: usize, const OUTS: usize>
+	VariableAnchorCircuit<F, P, HG, N, M, INS, OUTS>
 where
 	F: PrimeField,
 	P: TEModelParameters<BaseField = F>,
 	HG: FieldHasherGadget<F, P>,
 {
 	pub fn new(
-        public_amount: F,
-        public_chain_id: F,
-        in_amounts: [F; INS],
-        in_blindings: [F; INS],
-        in_nullifier_hashes: [F; INS],
-        in_private_keys: [F; INS],
-        in_paths: [Path<F, HG::Native, N>; INS],
-        in_indices: [F; INS],
-        in_root_set: [F; M],
-        out_amounts: [F; OUTS],
-        out_blindings: [F; OUTS],
-        out_chain_ids: [F; OUTS],
-        out_public_keys: [F; OUTS],
-        out_commitments: [F; OUTS],
-        arbitrary_data: F,
-        public_key_hasher: HG::Native,
-        tree_hasher: HG::Native,
-        signature_hasher: HG::Native,
-        leaf_hasher: HG::Native
+		public_amount: F,
+		public_chain_id: F,
+		in_amounts: [F; INS],
+		in_blindings: [F; INS],
+		in_nullifier_hashes: [F; INS],
+		in_private_keys: [F; INS],
+		in_paths: [Path<F, HG::Native, N>; INS],
+		in_indices: [F; INS],
+		in_root_set: [F; M],
+		out_amounts: [F; OUTS],
+		out_blindings: [F; OUTS],
+		out_chain_ids: [F; OUTS],
+		out_public_keys: [F; OUTS],
+		out_commitments: [F; OUTS],
+		arbitrary_data: F,
+		public_key_hasher: HG::Native,
+		tree_hasher: HG::Native,
+		signature_hasher: HG::Native,
+		leaf_hasher: HG::Native,
 	) -> Self {
 		Self {
-            public_amount,
-            public_chain_id,
-            in_amounts,
-            in_blindings,
-            in_nullifier_hashes,
-            in_private_keys,
-            in_paths,
-            in_indices,
-            in_root_set,
-            out_amounts,
-            out_blindings,
-            out_chain_ids,
-            out_public_keys,
-            out_commitments,
-            arbitrary_data,
-            public_key_hasher,
-            tree_hasher,
-            signature_hasher,
-            leaf_hasher,
+			public_amount,
+			public_chain_id,
+			in_amounts,
+			in_blindings,
+			in_nullifier_hashes,
+			in_private_keys,
+			in_paths,
+			in_indices,
+			in_root_set,
+			out_amounts,
+			out_blindings,
+			out_chain_ids,
+			out_public_keys,
+			out_commitments,
+			arbitrary_data,
+			public_key_hasher,
+			tree_hasher,
+			signature_hasher,
+			leaf_hasher,
 		}
 	}
 }
 
-impl<F, P, HG, const N: usize, const M: usize, const INS: usize, const OUTS: usize> Circuit<F, P> for VariableAnchorCircuit<F, P, HG, N, M, INS, OUTS>
+impl<F, P, HG, const N: usize, const M: usize, const INS: usize, const OUTS: usize> Circuit<F, P>
+	for VariableAnchorCircuit<F, P, HG, N, M, INS, OUTS>
 where
 	F: PrimeField,
 	P: TEModelParameters<BaseField = F>,
@@ -152,164 +156,146 @@ where
 	const CIRCUIT_ID: [u8; 32] = [0xff; 32];
 
 	fn gadget(&mut self, composer: &mut StandardComposer<F, P>) -> Result<(), Error> {
-        // Initialize public inputs
-        let public_amount = add_public_input_variable(composer, self.public_amount);
-        let public_chain_id = add_public_input_variable(composer, self.public_chain_id);
-        let roots = self
-            .in_root_set
-            .iter()
-            .map(|root| add_public_input_variable(composer, *root))
-            .collect::<Vec<Variable>>();
+		// Initialize public inputs
+		let public_amount = add_public_input_variable(composer, self.public_amount);
+		let public_chain_id = add_public_input_variable(composer, self.public_chain_id);
+		let roots = self
+			.in_root_set
+			.iter()
+			.map(|root| add_public_input_variable(composer, *root))
+			.collect::<Vec<Variable>>();
+		let arbitrary_data = add_public_input_variable(composer, self.arbitrary_data);
 
-        // Initialize hashers
-        let pk_hasher_gadget: HG = FieldHasherGadget::<F, P>::from_native(composer, self.public_key_hasher.clone());
-        let tree_hasher_gadget: HG = FieldHasherGadget::<F, P>::from_native(composer, self.tree_hasher.clone());
-        let sig_hasher_gadget: HG = FieldHasherGadget::<F, P>::from_native(composer, self.signature_hasher.clone());
-        let leaf_hasher_gadget: HG = FieldHasherGadget::<F, P>::from_native(composer, self.leaf_hasher.clone());
+		// Initialize hashers
+		let pk_hasher_gadget: HG =
+			FieldHasherGadget::<F, P>::from_native(composer, self.public_key_hasher.clone());
+		let tree_hasher_gadget: HG =
+			FieldHasherGadget::<F, P>::from_native(composer, self.tree_hasher.clone());
+		let sig_hasher_gadget: HG =
+			FieldHasherGadget::<F, P>::from_native(composer, self.signature_hasher.clone());
+		let leaf_hasher_gadget: HG =
+			FieldHasherGadget::<F, P>::from_native(composer, self.leaf_hasher.clone());
 
-        // Sum of input amounts + public amount must equal output amounts at the end
-        let mut input_sum = public_amount;
-        let mut output_sum = composer.zero_var();
+		// Sum of input amounts + public amount must equal output amounts at the end
+		let mut input_sum = public_amount;
+		let mut output_sum = composer.zero_var();
 
-        // Storage for the nullifier hash variables as we allocate them
-        let nullifier_hashes: Vec<Variable> = Vec::new();
+		// Storage for the nullifier hash variables as we allocate them
+		let nullifier_hashes: Vec<Variable> = Vec::new();
 
-        // General strategy
-        // 1. Reconstruct the commitments (along the way reconstruct other values)
-        // 2. Reconstruct the target merkle root with the input's merkle path
-        // 3. Verify that the target merkle root is within the root set
-        // 4. Sum the input amounts
-        for i in 0..INS {
-            // Private inputs for each input UTXO being spent
-            let in_private_key_i = composer.add_input(self.in_private_keys[i]);
-            let in_amount_i = composer.add_input(self.in_amounts[i]);
-            let in_blinding_i = composer.add_input(self.in_blindings[i]);
-            let in_index_i = composer.add_input(self.in_indices[i]);
-            let path_gadget = PathGadget::<F, P, HG, N>::from_native(
-                composer,
-                self.in_paths[i].clone()
-            );
+		// General strategy
+		// 1. Reconstruct the commitments (along the way reconstruct other values)
+		// 2. Reconstruct the target merkle root with the input's merkle path
+		// 3. Verify that the target merkle root is within the root set
+		// 4. Sum the input amounts
+		for i in 0..INS {
+			// Private inputs for each input UTXO being spent
+			let in_private_key_i = composer.add_input(self.in_private_keys[i]);
+			let in_amount_i = composer.add_input(self.in_amounts[i]);
+			let in_blinding_i = composer.add_input(self.in_blindings[i]);
+			let in_index_i = composer.add_input(self.in_indices[i]);
+			let path_gadget =
+				PathGadget::<F, P, HG, N>::from_native(composer, self.in_paths[i].clone());
 
-            // Add public inputs for each input UTXO being spent
-            let in_nullifier_hash_i = add_public_input_variable(composer, self.in_nullifier_hashes[i]);
-            nullifier_hashes.push(in_nullifier_hash_i);
+			// Add public inputs for each input UTXO being spent
+			let in_nullifier_hash_i =
+				add_public_input_variable(composer, self.in_nullifier_hashes[i]);
+			nullifier_hashes.push(in_nullifier_hash_i);
 
-            // Computing the public key, which is done, just by hashing the private key
-            let calc_public_key = pk_hasher_gadget.hash(composer, &[in_private_key_i])?;
+			// Computing the public key, which is done, just by hashing the private key
+			let calc_public_key = pk_hasher_gadget.hash(composer, &[in_private_key_i])?;
 
-            // Computing the leaf
-            let calc_leaf = leaf_hasher_gadget.hash(composer, &[
-                public_chain_id,
-                in_amount_i,
-                calc_public_key,
-                in_blinding_i,
-            ])?;
+			// Computing the leaf
+			let calc_leaf = leaf_hasher_gadget.hash(composer, &[
+				public_chain_id,
+				in_amount_i,
+				calc_public_key,
+				in_blinding_i,
+			])?;
 
-            // Computing the signature: sign(private_key, leaf, input_index)
-            let calc_signature = sig_hasher_gadget.hash(composer, &[
-                in_private_key_i,
-                calc_leaf,
-                in_index_i,
-            ])?;
+			// Computing the signature: sign(private_key, leaf, input_index)
+			let calc_signature =
+				sig_hasher_gadget.hash(composer, &[in_private_key_i, calc_leaf, in_index_i])?;
 
-            // Computing the nullifier hash. This is used to prevent spending
-            // already spent UTXOs.
-            let calc_nullifier = sig_hasher_gadget.hash(composer, &[
-                calc_leaf,
-                in_index_i,
-                calc_signature
-            ])?;
+			// Computing the nullifier hash. This is used to prevent spending
+			// already spent UTXOs.
+			let calc_nullifier =
+				sig_hasher_gadget.hash(composer, &[calc_leaf, in_index_i, calc_signature])?;
 
-            // Checking if the passed nullifier hash is the same as the calculated one
-            // Optimized version of allocating public nullifier input and constraining
-            // to the calculate one.
-            let _ = composer.arithmetic_gate( |gate|
-                gate.witness( 
-                    calc_nullifier,
-                    calc_nullifier,
-                    Some(composer.zero_var())
-                ).add(
-                    - F::one(),
-                    F::zero()
-                ).pi(self.in_nullifier_hashes[i])
-            );
+			// Checking if the passed nullifier hash is the same as the calculated one
+			// Optimized version of allocating public nullifier input and constraining
+			// to the calculate one.
+			let _ = composer.arithmetic_gate(|gate| {
+				gate.witness(calc_nullifier, calc_nullifier, Some(composer.zero_var()))
+					.add(-F::one(), F::zero())
+					.pi(self.in_nullifier_hashes[i])
+			});
 
-            // Calculate the root hash
-            let calc_root_hash = path_gadget.calculate_root(composer, &calc_leaf, &tree_hasher_gadget)?;
+			// Calculate the root hash
+			let calc_root_hash =
+				path_gadget.calculate_root(composer, &calc_leaf, &tree_hasher_gadget)?;
 
-            // Check if calculated root hash is in the set
-            // TODO: Check membership enabled is needed here.
-            let is_member = check_set_membership(composer, roots, calc_root_hash);
-            composer.constrain_to_constant(is_member, F::one(), None);
-            
-            // Finally add the amount to the sum
-            // TODO: Investigate improvements to accumulating sums
-            input_sum = composer.arithmetic_gate( |gate|
-                gate.witness( 
-                    input_sum,
-                    in_amount_i,
-                    None
-                ).add(
-                    F::one(),
-                    F::one()
-                )
-            );
-        }
+			// Check if calculated root hash is in the set
+			// TODO: Check membership enabled is needed here.
+			let is_member = check_set_membership(composer, roots, calc_root_hash);
+			composer.constrain_to_constant(is_member, F::one(), None);
 
-        // Check all the nullifiers are unique to prevent double-spending
-        // TODO: Investigate checking nullifier uniqueness this check to the application side
-        for i in 0..INS {
-            for j in (i + 1)..INS {
-                let result = composer.is_eq_with_output(nullifier_hashes[i], nullifier_hashes[j]);
-                composer.assert_equal(result, composer.zero_var());
-            }
-        }
+			// Finally add the amount to the sum
+			// TODO: Investigate improvements to accumulating sums
+			input_sum = composer.arithmetic_gate(|gate| {
+				gate.witness(input_sum, in_amount_i, None)
+					.add(F::one(), F::one())
+			});
+		}
 
-        for i in 0..OUTS {
-            let out_chain_id_i = composer.add_input(self.out_chain_ids[i]);
-            let out_amount_i = composer.add_input(self.out_amounts[i]);
-            let out_public_key_i = composer.add_input(self.out_public_keys[i]);
-            let out_blinding_i = composer.add_input(self.out_blindings[i]);
-            // Calculate the leaf commitment
-            let calc_leaf = leaf_hasher_gadget.hash(composer, &[
-                out_chain_id_i,
-                out_amount_i,
-                out_public_key_i,
-                out_blinding_i,
-            ])?;
-            
-            // Check if calculated leaf is the same as the passed one
-            let _ = composer.arithmetic_gate( |gate|
-                gate.witness( 
-                    calc_leaf,
-                    calc_leaf,
-                    Some(composer.zero_var())
-                ).add(
-                    - F::one(),
-                    F::zero()
-                ).pi(self.out_commitments[i])
-            );
-            
-            
-            // Each amount should not be greater than the limit constant
-            // TODO: Investigate if we can get the field size bits
-            composer.range_gate(out_amount_i, 254);
-            // assert_less_than(out_amounts[i], limit);
-            
-            // Add in to the sum
-            output_sum = composer.arithmetic_gate( |gate|
-                gate.witness( 
-                    output_sum,
-                    out_amount_i,
-                    None
-                ).add(
-                    F::one(),
-                    F::one()
-                )
-            );
-        }
+		// Check all the nullifiers are unique to prevent double-spending
+		// TODO: Investigate checking nullifier uniqueness this check to the application
+		// side
+		for i in 0..INS {
+			for j in (i + 1)..INS {
+				let result = composer.is_eq_with_output(nullifier_hashes[i], nullifier_hashes[j]);
+				composer.assert_equal(result, composer.zero_var());
+			}
+		}
 
-        composer.assert_equal(input_sum, output_sum);
+		for i in 0..OUTS {
+			let out_chain_id_i = composer.add_input(self.out_chain_ids[i]);
+			let out_amount_i = composer.add_input(self.out_amounts[i]);
+			let out_public_key_i = composer.add_input(self.out_public_keys[i]);
+			let out_blinding_i = composer.add_input(self.out_blindings[i]);
+			// Calculate the leaf commitment
+			let calc_leaf = leaf_hasher_gadget.hash(composer, &[
+				out_chain_id_i,
+				out_amount_i,
+				out_public_key_i,
+				out_blinding_i,
+			])?;
+
+			// Check if calculated leaf is the same as the passed one
+			let _ = composer.arithmetic_gate(|gate| {
+				gate.witness(calc_leaf, calc_leaf, Some(composer.zero_var()))
+					.add(-F::one(), F::zero())
+					.pi(self.out_commitments[i])
+			});
+
+			// Each amount should not be greater than the limit constant
+			// TODO: Investigate if we can get the field size bits
+			composer.range_gate(out_amount_i, 254);
+			// assert_less_than(out_amounts[i], limit);
+
+			// Add in to the sum
+			output_sum = composer.arithmetic_gate(|gate| {
+				gate.witness(output_sum, out_amount_i, None)
+					.add(F::one(), F::one())
+			});
+		}
+
+		composer.assert_equal(input_sum, output_sum);
+
+		let _arbitrary_data_squared = composer.arithmetic_gate(|gate| {
+			gate.witness(arbitrary_data, arbitrary_data, None)
+				.mul(F::one())
+		});
 
 		Ok(())
 	}
@@ -348,8 +334,8 @@ mod test {
 	type PoseidonBn254 = Poseidon<Fq>;
 
 	const BRIDGE_SIZE: usize = 2;
-    const INS: usize = 2;
-    const OUTS: usize = 2;
+	const INS: usize = 2;
+	const OUTS: usize = 2;
 
 	#[test]
 	fn should_verify_correct_anchor_plonk() {
@@ -392,17 +378,24 @@ mod test {
 		let path = tree.generate_membership_proof(last_index as u64);
 
 		// Create VariableAnchorCircuit
-		let mut anchor =
-			VariableAnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE, INS, OUTS>::new(
-				chain_id,
-				secret,
-				nullifier,
-				nullifier_hash,
-				path,
-				roots,
-				arbitrary_data,
-				poseidon_native,
-			);
+		let mut anchor = VariableAnchorCircuit::<
+			Bn254Fr,
+			JubjubParameters,
+			PoseidonGadget,
+			HEIGHT,
+			BRIDGE_SIZE,
+			INS,
+			OUTS,
+		>::new(
+			chain_id,
+			secret,
+			nullifier,
+			nullifier_hash,
+			path,
+			roots,
+			arbitrary_data,
+			poseidon_native,
+		);
 
 		let res = gadget_tester::<Bn254, JubjubParameters, _>(&mut anchor, 1 << 17);
 		assert!(res.is_ok(), "{:?}", res.err().unwrap());
@@ -450,17 +443,24 @@ mod test {
 		let path = tree.generate_membership_proof(last_index as u64);
 
 		// Create VariableAnchorCircuit
-		let mut anchor =
-			VariableAnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE, INS, OUTS>::new(
-				chain_id,
-				secret,
-				nullifier,
-				nullifier_hash,
-				path,
-				roots,
-				arbitrary_data,
-				poseidon_native,
-			);
+		let mut anchor = VariableAnchorCircuit::<
+			Bn254Fr,
+			JubjubParameters,
+			PoseidonGadget,
+			HEIGHT,
+			BRIDGE_SIZE,
+			INS,
+			OUTS,
+		>::new(
+			chain_id,
+			secret,
+			nullifier,
+			nullifier_hash,
+			path,
+			roots,
+			arbitrary_data,
+			poseidon_native,
+		);
 
 		// Fill a composer to extract the public_inputs
 		let mut composer = StandardComposer::<Bn254Fr, JubjubParameters>::new();
@@ -472,7 +472,11 @@ mod test {
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
 		let proof = {
 			// Create a prover struct
-			let mut prover = Prover::<Bn254, JubjubParameters, SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>>::new(b"vanchor");
+			let mut prover = Prover::<
+				Bn254,
+				JubjubParameters,
+				SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
+			>::new(b"vanchor");
 			prover.key_transcript(b"key", b"additional seed information");
 			// Add gadgets
 			let _ = anchor.gadget(prover.mut_cs());
@@ -501,9 +505,7 @@ mod test {
 		verifier.preprocess(&ck.powers()).unwrap();
 
 		// Verify proof
-		let res = verifier
-			.verify(&proof, &vk, &public_inputs)
-			.unwrap_err();
+		let res = verifier.verify(&proof, &vk, &public_inputs).unwrap_err();
 		match res {
 			Error::ProofVerificationError => (),
 			err => panic!("Unexpected error: {:?}", err),
@@ -552,17 +554,24 @@ mod test {
 		let bad_secret = secret.double();
 
 		// Create VariableAnchorCircuit
-		let mut anchor =
-			VariableAnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE, INS, OUTS>::new(
-				chain_id,
-				bad_secret,
-				nullifier,
-				nullifier_hash,
-				path,
-				roots,
-				arbitrary_data,
-				poseidon_native,
-			);
+		let mut anchor = VariableAnchorCircuit::<
+			Bn254Fr,
+			JubjubParameters,
+			PoseidonGadget,
+			HEIGHT,
+			BRIDGE_SIZE,
+			INS,
+			OUTS,
+		>::new(
+			chain_id,
+			bad_secret,
+			nullifier,
+			nullifier_hash,
+			path,
+			roots,
+			arbitrary_data,
+			poseidon_native,
+		);
 
 		// Fill a composer to extract the public_inputs
 		let mut composer = StandardComposer::<Bn254Fr, JubjubParameters>::new();
@@ -574,7 +583,11 @@ mod test {
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
 		let proof = {
 			// Create a prover struct
-			let mut prover = Prover::<Bn254, JubjubParameters, SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>>::new(b"vanchor");
+			let mut prover = Prover::<
+				Bn254,
+				JubjubParameters,
+				SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
+			>::new(b"vanchor");
 			prover.key_transcript(b"key", b"additional seed information");
 			// Add gadgets
 			let _ = anchor.gadget(prover.mut_cs());
@@ -658,17 +671,24 @@ mod test {
 		let bad_nullifier = nullifier.double();
 
 		// Create VariableAnchorCircuit
-		let mut anchor =
-			VariableAnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE, INS, OUTS>::new(
-				chain_id,
-				secret,
-				bad_nullifier,
-				nullifier_hash,
-				path,
-				roots,
-				arbitrary_data,
-				poseidon_native,
-			);
+		let mut anchor = VariableAnchorCircuit::<
+			Bn254Fr,
+			JubjubParameters,
+			PoseidonGadget,
+			HEIGHT,
+			BRIDGE_SIZE,
+			INS,
+			OUTS,
+		>::new(
+			chain_id,
+			secret,
+			bad_nullifier,
+			nullifier_hash,
+			path,
+			roots,
+			arbitrary_data,
+			poseidon_native,
+		);
 
 		// Fill a composer to extract the public_inputs
 		let mut composer = StandardComposer::<Bn254Fr, JubjubParameters>::new();
@@ -680,7 +700,11 @@ mod test {
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
 		let proof = {
 			// Create a prover struct
-			let mut prover = Prover::<Bn254, JubjubParameters, SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>>::new(b"vanchor");
+			let mut prover = Prover::<
+				Bn254,
+				JubjubParameters,
+				SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
+			>::new(b"vanchor");
 			prover.key_transcript(b"key", b"additional seed information");
 			// Add gadgets
 			let _ = anchor.gadget(prover.mut_cs());
@@ -761,17 +785,24 @@ mod test {
 		let bad_path = tree.generate_membership_proof((last_index as u64) - 1);
 
 		// Create VariableAnchorCircuit
-		let mut anchor =
-			VariableAnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE, INS, OUTS>::new(
-				chain_id,
-				secret,
-				nullifier,
-				nullifier_hash,
-				bad_path,
-				roots,
-				arbitrary_data,
-				poseidon_native,
-			);
+		let mut anchor = VariableAnchorCircuit::<
+			Bn254Fr,
+			JubjubParameters,
+			PoseidonGadget,
+			HEIGHT,
+			BRIDGE_SIZE,
+			INS,
+			OUTS,
+		>::new(
+			chain_id,
+			secret,
+			nullifier,
+			nullifier_hash,
+			bad_path,
+			roots,
+			arbitrary_data,
+			poseidon_native,
+		);
 
 		// Fill a composer to extract the public_inputs
 		let mut composer = StandardComposer::<Bn254Fr, JubjubParameters>::new();
@@ -783,7 +814,11 @@ mod test {
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
 		let proof = {
 			// Create a prover struct
-			let mut prover = Prover::<Bn254, JubjubParameters, SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>>::new(b"vanchor");
+			let mut prover = Prover::<
+				Bn254,
+				JubjubParameters,
+				SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
+			>::new(b"vanchor");
 			prover.key_transcript(b"key", b"additional seed information");
 			// Add gadgets
 			let _ = anchor.gadget(prover.mut_cs());
@@ -867,17 +902,24 @@ mod test {
 		let bad_nullifier_hash = nullifier_hash.double();
 
 		// Create VariableAnchorCircuit
-		let mut anchor =
-			VariableAnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE, INS, OUTS>::new(
-				chain_id,
-				secret,
-				nullifier,
-				bad_nullifier_hash,
-				path,
-				roots,
-				arbitrary_data,
-				poseidon_native,
-			);
+		let mut anchor = VariableAnchorCircuit::<
+			Bn254Fr,
+			JubjubParameters,
+			PoseidonGadget,
+			HEIGHT,
+			BRIDGE_SIZE,
+			INS,
+			OUTS,
+		>::new(
+			chain_id,
+			secret,
+			nullifier,
+			bad_nullifier_hash,
+			path,
+			roots,
+			arbitrary_data,
+			poseidon_native,
+		);
 
 		// Fill a composer to extract the public_inputs
 		let mut composer = StandardComposer::<Bn254Fr, JubjubParameters>::new();
@@ -889,7 +931,11 @@ mod test {
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
 		let proof = {
 			// Create a prover struct
-			let mut prover = Prover::<Bn254, JubjubParameters, SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>>::new(b"vanchor");
+			let mut prover = Prover::<
+				Bn254,
+				JubjubParameters,
+				SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
+			>::new(b"vanchor");
 			prover.key_transcript(b"key", b"additional seed information");
 			// Add gadgets
 			let _ = anchor.gadget(prover.mut_cs());
@@ -970,17 +1016,24 @@ mod test {
 		let path = tree.generate_membership_proof(last_index as u64);
 
 		// Create VariableAnchorCircuit
-		let mut anchor =
-			VariableAnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE, INS, OUTS>::new(
-				chain_id,
-				secret,
-				nullifier,
-				nullifier_hash,
-				path,
-				roots,
-				arbitrary_data,
-				poseidon_native,
-			);
+		let mut anchor = VariableAnchorCircuit::<
+			Bn254Fr,
+			JubjubParameters,
+			PoseidonGadget,
+			HEIGHT,
+			BRIDGE_SIZE,
+			INS,
+			OUTS,
+		>::new(
+			chain_id,
+			secret,
+			nullifier,
+			nullifier_hash,
+			path,
+			roots,
+			arbitrary_data,
+			poseidon_native,
+		);
 
 		// Fill a composer to extract the public_inputs
 		let mut composer = StandardComposer::<Bn254Fr, JubjubParameters>::new();
@@ -992,7 +1045,11 @@ mod test {
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
 		let proof = {
 			// Create a prover struct
-			let mut prover = Prover::<Bn254, JubjubParameters, SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>>::new(b"vanchor");
+			let mut prover = Prover::<
+				Bn254,
+				JubjubParameters,
+				SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>,
+			>::new(b"vanchor");
 			prover.key_transcript(b"key", b"additional seed information");
 			// Add gadgets
 			let _ = anchor.gadget(prover.mut_cs());

--- a/arkworks-plonk-circuits/src/vanchor/mod.rs
+++ b/arkworks-plonk-circuits/src/vanchor/mod.rs
@@ -436,7 +436,7 @@ mod test {
 			path: [(Fq::from(0u64), Fq::from(0u64)); TREE_HEIGHT],
 			_marker: PhantomData,
 		};
-		let mut in_paths = [default_path; INS];
+		let mut in_paths: [Path<_,_,TREE_HEIGHT>; INS] = [default_path.clone(), default_path];
 		// let mut in_paths_vec: Vec<Path::<Fq, PoseidonBn254, TREE_HEIGHT>>;
 		// We'll say the index of each input is index:
 		let index = 0u64;

--- a/arkworks-plonk-circuits/src/vanchor/mod.rs
+++ b/arkworks-plonk-circuits/src/vanchor/mod.rs
@@ -435,12 +435,9 @@ mod test {
 			in_paths[i] = merkle_tree.generate_membership_proof(i as u64);
 		}
 
-		// The root set should contain this merkle tree's root, which
-		// can be gotten from any of the above paths since they all
-		// belong to same tree.
-		in_root_set[0] = in_paths[0]
-			.calculate_root(&in_leaf_hashes[0], &poseidon_native3)
-			.unwrap();
+		// The root set should contain this merkle tree's root
+		in_root_set[0] = merkle_tree.root();
+
 
 		// Output amounts: (remember input amounts sum to 6 and there is also the public
 		// amount)
@@ -605,9 +602,7 @@ mod test {
 		in_paths[1] = merkle_tree.generate_membership_proof(index);
 
 		// Add the root of this Merkle tree to the root set.
-		in_root_set[0] = in_paths[1]
-			.calculate_root(&leaf, &poseidon_native3)
-			.unwrap();
+		in_root_set[0] = merkle_tree.root();
 
 		// Output amounts should sum to inputs plus public amount.
 		// In this case the first output is 0 and the remaining output
@@ -767,9 +762,7 @@ mod test {
 		in_paths[1] = merkle_tree.generate_membership_proof(index);
 
 		// Add the root of this Merkle tree to the root set.
-		in_root_set[0] = in_paths[1]
-			.calculate_root(&leaf, &poseidon_native3)
-			.unwrap();
+		in_root_set[0] = merkle_tree.root();
 
 		// Output amounts cannot be randomly generated since they may then exceed input
 		// amount.
@@ -946,9 +939,7 @@ mod test {
 		in_paths[1] = merkle_tree.generate_membership_proof(index);
 
 		// Add the root of this Merkle tree to the root set.
-		in_root_set[0] = in_paths[1]
-			.calculate_root(&leaf, &poseidon_native3)
-			.unwrap();
+		in_root_set[0] = merkle_tree.root();
 
 		// Change the second secret to something incorrect
 		in_private_keys[1] = Fq::from(0u32);
@@ -1112,9 +1103,7 @@ mod test {
 		in_paths[1] = merkle_tree.generate_membership_proof(index);
 
 		// Add the root of this Merkle tree to the root set.
-		in_root_set[0] = in_paths[1]
-			.calculate_root(&leaf, &poseidon_native3)
-			.unwrap();
+		in_root_set[0] = merkle_tree.root();
 
 		// Output amounts cannot be randomly generated since they may then exceed input
 		// amount.
@@ -1292,9 +1281,7 @@ mod test {
 		in_paths[1] = merkle_tree.generate_membership_proof(index);
 
 		// Add the root of this Merkle tree to the root set.
-		in_root_set[0] = in_paths[1]
-			.calculate_root(&leaf, &poseidon_native3)
-			.unwrap();
+		in_root_set[0] = merkle_tree.root();
 
 		// Change the first path to something incorrect
 		in_paths[0] = default_path;
@@ -1458,9 +1445,7 @@ mod test {
 		in_paths[1] = merkle_tree.generate_membership_proof(index);
 
 		// Add the root of this Merkle tree to the root set.
-		in_root_set[0] = in_paths[1]
-			.calculate_root(&leaf, &poseidon_native3)
-			.unwrap();
+		in_root_set[0] = merkle_tree.root();
 
 		// Output amounts cannot be randomly generated since they may then exceed input
 		// amount.
@@ -1637,9 +1622,7 @@ mod test {
 		in_paths[1] = merkle_tree.generate_membership_proof(index);
 
 		// Add the root of this Merkle tree to the root set.
-		in_root_set[0] = in_paths[1]
-			.calculate_root(&leaf, &poseidon_native3)
-			.unwrap();
+		in_root_set[0] = merkle_tree.root();
 
 		// Output amounts cannot be randomly generated since they may then exceed input
 		// amount.
@@ -1816,9 +1799,7 @@ mod test {
 		in_paths[1] = merkle_tree.generate_membership_proof(index);
 
 		// Add the root of this Merkle tree to the root set.
-		in_root_set[0] = in_paths[1]
-			.calculate_root(&leaf, &poseidon_native3)
-			.unwrap();
+		in_root_set[0] = merkle_tree.root();
 
 		// Output amounts cannot be randomly generated since they may then exceed input
 		// amount.

--- a/arkworks-plonk-circuits/src/vanchor/mod.rs
+++ b/arkworks-plonk-circuits/src/vanchor/mod.rs
@@ -1,6 +1,26 @@
+// VAnchor is the variable deposit/withdraw/transfer shielded pool
+// It supports join split transactions, meaning you can take unspent deposits
+// in the pool and join them together, split them, and any combination
+// of the two.
+
+// The inputs to the VAnchor are unspent outputs we want to spend (we are spending the inputs),
+// and we create outputs which are new, unspent UTXOs. We create commitments
+// for each output and these are inserted into merkle trees.
+
+// The VAnchor is also a bridged system. It takes as a public input
+// a set of merkle roots that it will use to verify the membership
+// of unspent deposits within. The VAnchor prevents double-spending
+// through the use of a public input chain identifier `chain_id`.
+
+// We will take inputs and do a merkle tree reconstruction for each input.
+// Then we will verify that the reconstructed root from each input's
+// membership path is within a set of public merkle roots.
+
+use std::ops::Add;
+
 use crate::{
-	merkle_tree::PathGadget, anchor::add_public_input_variable,
-	poseidon::poseidon::FieldHasherGadget, set_membership::check_set_membership,
+	merkle_tree::{PatHadget, PathGadget}, vanchor::add_public_input_variable,
+	poseidon::poseidon::FieldHasherGadget, set_membership::check_set_membership, mixer::add_public_input_variable,
 };
 use ark_ec::{models::TEModelParameters, PairingEngine};
 use ark_ff::PrimeField;
@@ -9,54 +29,121 @@ use arkworks_gadgets::merkle_tree::simple_merkle::Path;
 use plonk_core::{
 	circuit::Circuit, constraint_system::StandardComposer, error::Error, prelude::Variable,
 };
+use arkworks_gadgets::poseidon::field_hasher::FieldHasher;
 
-pub struct AnchorCircuit<
+pub struct VariableAnchorCircuit<
 	F: PrimeField,
 	P: TEModelParameters<BaseField = F>,
 	HG: FieldHasherGadget<F, P>,
+    // Tree height
 	const N: usize,
+    // Size of the root set (bridge length)
 	const M: usize,
+    // Number of inputs
+    const INS: usize,
+    // Number of outputs
+    const OUTS: usize,
 > {
-	chain_id: F,
-	secret: F,
-	nullifier: F,
-	nullifier_hash: F,
-	path: Path<F, HG::Native, N>,
-	roots: [F; M],
-	arbitrary_data: F,
-	hasher: HG::Native,
+	// chain_id: F,
+	// secret: F,
+	// nullifier: F,
+	// nullifier_hash: F,
+	// path: Path<F, H::Native, N>,
+	// roots: [F; M],
+	// arbitrary_data: F,
+	// hasher: H::Native,
+
+    // INS = number of input transactions
+    // OUTS = number of output transactions
+    // N = Tree height
+    // M = Size of the root set
+
+    // sum of input amounts + public amount == sum of output amounts
+    public_amount: F, // Public
+    public_chain_id: F, // Public
+
+    // Input transactions
+    in_amounts: [F; INS],
+    in_blindings: [F; INS],
+    in_nullifier_hashes: [F; INS], // Public
+    in_private_keys: [F; INS],
+    in_paths: [Path<F, HG::Native, N>; INS],
+    in_indices: [F; INS],
+    in_root_set: [F; M],
+
+    // Output transactions 
+    out_amounts: [F; OUTS],
+    out_blindings: [F; OUTS],
+    out_chain_ids: [F; OUTS],
+    out_public_keys: [F; OUTS],
+    out_commitments: [F; OUTS], // Public
+
+    // Arbitrary data to be added to the transcript
+    arbitrary_data: F, // Public
+
+    // All the hashers used in this circuit
+    // Used for hashing private_key -- width 2
+    public_key_hasher: HG::Native,
+    // Used for hashing nodes in the tree -- width 3
+    tree_hasher: HG::Native,
+    // Used for creating leaf signature and the nullifier hash -- width 4
+    signature_hasher: HG::Native,
+    // Used for creating leaf -- width 5
+    leaf_hasher: HG::Native
 }
 
-impl<F, P, HG, const N: usize, const M: usize> AnchorCircuit<F, P, HG, N, M>
+impl<F, P, HG, const N: usize, const M: usize, const INS: usize, const OUTS: usize> VariableAnchorCircuit<F, P, HG, N, M, INS, OUTS>
 where
 	F: PrimeField,
 	P: TEModelParameters<BaseField = F>,
 	HG: FieldHasherGadget<F, P>,
 {
 	pub fn new(
-		chain_id: F,
-		secret: F,
-		nullifier: F,
-		nullifier_hash: F,
-		path: Path<F, HG::Native, N>,
-		roots: [F; M],
-		arbitrary_data: F,
-		hasher: HG::Native,
+        public_amount: F,
+        public_chain_id: F,
+        in_amounts: [F; INS],
+        in_blindings: [F; INS],
+        in_nullifier_hashes: [F; INS],
+        in_private_keys: [F; INS],
+        in_paths: [Path<F, HG::Native, N>; INS],
+        in_indices: [F; INS],
+        in_root_set: [F; M],
+        out_amounts: [F; OUTS],
+        out_blindings: [F; OUTS],
+        out_chain_ids: [F; OUTS],
+        out_public_keys: [F; OUTS],
+        out_commitments: [F; OUTS],
+        arbitrary_data: F,
+        public_key_hasher: HG::Native,
+        tree_hasher: HG::Native,
+        signature_hasher: HG::Native,
+        leaf_hasher: HG::Native
 	) -> Self {
 		Self {
-			chain_id,
-			secret,
-			nullifier,
-			nullifier_hash,
-			path,
-			roots,
-			arbitrary_data,
-			hasher,
+            public_amount,
+            public_chain_id,
+            in_amounts,
+            in_blindings,
+            in_nullifier_hashes,
+            in_private_keys,
+            in_paths,
+            in_indices,
+            in_root_set,
+            out_amounts,
+            out_blindings,
+            out_chain_ids,
+            out_public_keys,
+            out_commitments,
+            arbitrary_data,
+            public_key_hasher,
+            tree_hasher,
+            signature_hasher,
+            leaf_hasher,
 		}
 	}
 }
 
-impl<F, P, HG, const N: usize, const M: usize> Circuit<F, P> for AnchorCircuit<F, P, HG, N, M>
+impl<F, P, HG, const N: usize, const M: usize, const INS: usize, const OUTS: usize> Circuit<F, P> for VariableAnchorCircuit<F, P, HG, N, M, INS, OUTS>
 where
 	F: PrimeField,
 	P: TEModelParameters<BaseField = F>,
@@ -65,45 +152,165 @@ where
 	const CIRCUIT_ID: [u8; 32] = [0xff; 32];
 
 	fn gadget(&mut self, composer: &mut StandardComposer<F, P>) -> Result<(), Error> {
-		// Private Inputs
-		let secret = composer.add_input(self.secret);
-		let nullifier = composer.add_input(self.nullifier);
-		let path_gadget = PathGadget::<F, P, HG, N>::from_native(composer, self.path.clone());
+        // Initialize public inputs
+        let public_amount = add_public_input_variable(composer, self.public_amount);
+        let public_chain_id = add_public_input_variable(composer, self.public_chain_id);
+        let roots = self
+            .in_root_set
+            .iter()
+            .map(|root| add_public_input_variable(composer, *root))
+            .collect::<Vec<Variable>>();
 
-		// Public Inputs
-		let chain_id = add_public_input_variable(composer, self.chain_id);
-		let nullifier_hash = add_public_input_variable(composer, self.nullifier_hash);
-		let roots = self
-			.roots
-			.iter()
-			.map(|root| add_public_input_variable(composer, *root))
-			.collect::<Vec<Variable>>();
-		let arbitrary_data = add_public_input_variable(composer, self.arbitrary_data);
+        // Initialize hashers
+        let pk_hasher_gadget: HG = FieldHasherGadget::<F, P>::from_native(composer, self.public_key_hasher.clone());
+        let tree_hasher_gadget: HG = FieldHasherGadget::<F, P>::from_native(composer, self.tree_hasher.clone());
+        let sig_hasher_gadget: HG = FieldHasherGadget::<F, P>::from_native(composer, self.signature_hasher.clone());
+        let leaf_hasher_gadget: HG = FieldHasherGadget::<F, P>::from_native(composer, self.leaf_hasher.clone());
 
-		// Create the hasher_gadget from native
-		let hasher_gadget: HG =
-			FieldHasherGadget::<F, P>::from_native(composer, self.hasher.clone());
+        // Sum of input amounts + public amount must equal output amounts at the end
+        let mut input_sum = public_amount;
+        let mut output_sum = composer.zero_var();
 
-		// Preimage proof of nullifier
-		let res_nullifier = hasher_gadget.hash_two(composer, &nullifier, &nullifier)?;
-		// TODO: (This has 1 more gate than skipping the nullifier_hash variable and
-		// putting this straight in to a poly_gate)
-		composer.assert_equal(res_nullifier, nullifier_hash);
+        // Storage for the nullifier hash variables as we allocate them
+        let nullifier_hashes: Vec<Variable> = Vec::new();
 
-		// Preimage proof of leaf hash
-		let res_leaf = hasher_gadget.hash_two(composer, &secret, &nullifier)?;
+        // General strategy
+        // 1. Reconstruct the commitments (along the way reconstruct other values)
+        // 2. Reconstruct the target merkle root with the input's merkle path
+        // 3. Verify that the target merkle root is within the root set
+        // 4. Sum the input amounts
+        for i in 0..INS {
+            // Private inputs for each input UTXO being spent
+            let in_private_key_i = composer.add_input(self.in_private_keys[i]);
+            let in_amount_i = composer.add_input(self.in_amounts[i]);
+            let in_blinding_i = composer.add_input(self.in_blindings[i]);
+            let in_index_i = composer.add_input(self.in_indices[i]);
+            let path_gadget = PathGadget::<F, P, HG, N>::from_native(
+                composer,
+                self.in_paths[i].clone()
+            );
 
-		// Proof of Merkle tree set membership
-		let calculated_root = path_gadget.calculate_root(composer, &res_leaf, &hasher_gadget)?;
-		let result = check_set_membership(composer, &self.roots.to_vec(), calculated_root);
-		let one = composer.add_witness_to_circuit_description(F::one());
-		composer.assert_equal(result, one);
+            // Add public inputs for each input UTXO being spent
+            let in_nullifier_hash_i = add_public_input_variable(composer, self.in_nullifier_hashes[i]);
+            nullifier_hashes.push(in_nullifier_hash_i);
 
-		// Safety constraint to prevent tampering with arbitrary_data
-		let _arbitrary_data_squared = composer.arithmetic_gate(|gate| {
-			gate.witness(arbitrary_data, arbitrary_data, None)
-				.mul(F::one())
-		});
+            // Computing the public key, which is done, just by hashing the private key
+            let calc_public_key = pk_hasher_gadget.hash(composer, &[in_private_key_i])?;
+
+            // Computing the leaf
+            let calc_leaf = leaf_hasher_gadget.hash(composer, &[
+                public_chain_id,
+                in_amount_i,
+                calc_public_key,
+                in_blinding_i,
+            ])?;
+
+            // Computing the signature: sign(private_key, leaf, input_index)
+            let calc_signature = sig_hasher_gadget.hash(composer, &[
+                in_private_key_i,
+                calc_leaf,
+                in_index_i,
+            ])?;
+
+            // Computing the nullifier hash. This is used to prevent spending
+            // already spent UTXOs.
+            let calc_nullifier = sig_hasher_gadget.hash(composer, &[
+                calc_leaf,
+                in_index_i,
+                calc_signature
+            ])?;
+
+            // Checking if the passed nullifier hash is the same as the calculated one
+            // Optimized version of allocating public nullifier input and constraining
+            // to the calculate one.
+            let _ = composer.arithmetic_gate( |gate|
+                gate.witness( 
+                    calc_nullifier,
+                    calc_nullifier,
+                    Some(composer.zero_var())
+                ).add(
+                    - F::one(),
+                    F::zero()
+                ).pi(self.in_nullifier_hashes[i])
+            );
+
+            // Calculate the root hash
+            let calc_root_hash = path_gadget.calculate_root(composer, &calc_leaf, &tree_hasher_gadget)?;
+
+            // Check if calculated root hash is in the set
+            // TODO: Check membership enabled is needed here.
+            let is_member = check_set_membership(composer, roots, calc_root_hash);
+            composer.constrain_to_constant(is_member, F::one(), None);
+            
+            // Finally add the amount to the sum
+            // TODO: Investigate improvements to accumulating sums
+            input_sum = composer.arithmetic_gate( |gate|
+                gate.witness( 
+                    input_sum,
+                    in_amount_i,
+                    None
+                ).add(
+                    F::one(),
+                    F::one()
+                )
+            );
+        }
+
+        // Check all the nullifiers are unique to prevent double-spending
+        // TODO: Investigate checking nullifier uniqueness this check to the application side
+        for i in 0..INS {
+            for j in (i + 1)..INS {
+                let result = composer.is_eq_with_output(nullifier_hashes[i], nullifier_hashes[j]);
+                composer.assert_equal(result, composer.zero_var());
+            }
+        }
+
+        for i in 0..OUTS {
+            let out_chain_id_i = composer.add_input(self.out_chain_ids[i]);
+            let out_amount_i = composer.add_input(self.out_amounts[i]);
+            let out_public_key_i = composer.add_input(self.out_public_keys[i]);
+            let out_blinding_i = composer.add_input(self.out_blindings[i]);
+            // Calculate the leaf commitment
+            let calc_leaf = leaf_hasher_gadget.hash(composer, &[
+                out_chain_id_i,
+                out_amount_i,
+                out_public_key_i,
+                out_blinding_i,
+            ])?;
+            
+            // Check if calculated leaf is the same as the passed one
+            let _ = composer.arithmetic_gate( |gate|
+                gate.witness( 
+                    calc_leaf,
+                    calc_leaf,
+                    Some(composer.zero_var())
+                ).add(
+                    - F::one(),
+                    F::zero()
+                ).pi(self.out_commitments[i])
+            );
+            
+            
+            // Each amount should not be greater than the limit constant
+            // TODO: Investigate if we can get the field size bits
+            composer.range_gate(out_amount_i, 254);
+            // assert_less_than(out_amounts[i], limit);
+            
+            // Add in to the sum
+            output_sum = composer.arithmetic_gate( |gate|
+                gate.witness( 
+                    output_sum,
+                    out_amount_i,
+                    None
+                ).add(
+                    F::one(),
+                    F::one()
+                )
+            );
+        }
+
+        composer.assert_equal(input_sum, output_sum);
+
 		Ok(())
 	}
 
@@ -114,7 +321,7 @@ where
 
 #[cfg(test)]
 mod test {
-	use super::AnchorCircuit;
+	use super::VariableAnchorCircuit;
 	use crate::{poseidon::poseidon::PoseidonGadget, utils::gadget_tester};
 	use ark_bn254::{Bn254, Fr as Bn254Fr};
 	use ark_ed_on_bn254::{EdwardsParameters as JubjubParameters, Fq};
@@ -141,6 +348,8 @@ mod test {
 	type PoseidonBn254 = Poseidon<Fq>;
 
 	const BRIDGE_SIZE: usize = 2;
+    const INS: usize = 2;
+    const OUTS: usize = 2;
 
 	#[test]
 	fn should_verify_correct_anchor_plonk() {
@@ -182,9 +391,9 @@ mod test {
 		// Path
 		let path = tree.generate_membership_proof(last_index as u64);
 
-		// Create AnchorCircuit
+		// Create VariableAnchorCircuit
 		let mut anchor =
-			AnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
+			VariableAnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE, INS, OUTS>::new(
 				chain_id,
 				secret,
 				nullifier,
@@ -240,9 +449,9 @@ mod test {
 		// Path
 		let path = tree.generate_membership_proof(last_index as u64);
 
-		// Create AnchorCircuit
+		// Create VariableAnchorCircuit
 		let mut anchor =
-			AnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
+			VariableAnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE, INS, OUTS>::new(
 				chain_id,
 				secret,
 				nullifier,
@@ -263,7 +472,7 @@ mod test {
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
 		let proof = {
 			// Create a prover struct
-			let mut prover = Prover::<Bn254, JubjubParameters, SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>>::new(b"anchor");
+			let mut prover = Prover::<Bn254, JubjubParameters, SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>>::new(b"vanchor");
 			prover.key_transcript(b"key", b"additional seed information");
 			// Add gadgets
 			let _ = anchor.gadget(prover.mut_cs());
@@ -280,7 +489,7 @@ mod test {
 		// Verifier's view
 
 		// Create a Verifier object
-		let mut verifier = Verifier::new(b"anchor");
+		let mut verifier = Verifier::new(b"vanchor");
 		verifier.key_transcript(b"key", b"additional seed information");
 		// Add gadgets
 		let _ = anchor.gadget(verifier.mut_cs());
@@ -342,9 +551,9 @@ mod test {
 		// An incorrect secret value to use below
 		let bad_secret = secret.double();
 
-		// Create AnchorCircuit
+		// Create VariableAnchorCircuit
 		let mut anchor =
-			AnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
+			VariableAnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE, INS, OUTS>::new(
 				chain_id,
 				bad_secret,
 				nullifier,
@@ -365,7 +574,7 @@ mod test {
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
 		let proof = {
 			// Create a prover struct
-			let mut prover = Prover::<Bn254, JubjubParameters, SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>>::new(b"anchor");
+			let mut prover = Prover::<Bn254, JubjubParameters, SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>>::new(b"vanchor");
 			prover.key_transcript(b"key", b"additional seed information");
 			// Add gadgets
 			let _ = anchor.gadget(prover.mut_cs());
@@ -382,7 +591,7 @@ mod test {
 		// Verifier's view
 
 		// Create a Verifier object
-		let mut verifier = Verifier::new(b"anchor");
+		let mut verifier = Verifier::new(b"vanchor");
 		verifier.key_transcript(b"key", b"additional seed information");
 		// Add gadgets
 		let _ = anchor.gadget(verifier.mut_cs());
@@ -448,9 +657,9 @@ mod test {
 		// An incorrect secret value to use below
 		let bad_nullifier = nullifier.double();
 
-		// Create AnchorCircuit
+		// Create VariableAnchorCircuit
 		let mut anchor =
-			AnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
+			VariableAnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE, INS, OUTS>::new(
 				chain_id,
 				secret,
 				bad_nullifier,
@@ -471,7 +680,7 @@ mod test {
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
 		let proof = {
 			// Create a prover struct
-			let mut prover = Prover::<Bn254, JubjubParameters, SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>>::new(b"anchor");
+			let mut prover = Prover::<Bn254, JubjubParameters, SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>>::new(b"vanchor");
 			prover.key_transcript(b"key", b"additional seed information");
 			// Add gadgets
 			let _ = anchor.gadget(prover.mut_cs());
@@ -488,7 +697,7 @@ mod test {
 		// Verifier's view
 
 		// Create a Verifier object
-		let mut verifier = Verifier::new(b"anchor");
+		let mut verifier = Verifier::new(b"vanchor");
 		verifier.key_transcript(b"key", b"additional seed information");
 		// Add gadgets
 		let _ = anchor.gadget(verifier.mut_cs());
@@ -551,9 +760,9 @@ mod test {
 		// An incorrect path to use below
 		let bad_path = tree.generate_membership_proof((last_index as u64) - 1);
 
-		// Create AnchorCircuit
+		// Create VariableAnchorCircuit
 		let mut anchor =
-			AnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
+			VariableAnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE, INS, OUTS>::new(
 				chain_id,
 				secret,
 				nullifier,
@@ -574,7 +783,7 @@ mod test {
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
 		let proof = {
 			// Create a prover struct
-			let mut prover = Prover::<Bn254, JubjubParameters, SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>>::new(b"anchor");
+			let mut prover = Prover::<Bn254, JubjubParameters, SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>>::new(b"vanchor");
 			prover.key_transcript(b"key", b"additional seed information");
 			// Add gadgets
 			let _ = anchor.gadget(prover.mut_cs());
@@ -591,7 +800,7 @@ mod test {
 		// Verifier's view
 
 		// Create a Verifier object
-		let mut verifier = Verifier::new(b"anchor");
+		let mut verifier = Verifier::new(b"vanchor");
 		verifier.key_transcript(b"key", b"additional seed information");
 		// Add gadgets
 		let _ = anchor.gadget(verifier.mut_cs());
@@ -657,9 +866,9 @@ mod test {
 		// Incorrect nullifier hash to use below
 		let bad_nullifier_hash = nullifier_hash.double();
 
-		// Create AnchorCircuit
+		// Create VariableAnchorCircuit
 		let mut anchor =
-			AnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
+			VariableAnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE, INS, OUTS>::new(
 				chain_id,
 				secret,
 				nullifier,
@@ -680,7 +889,7 @@ mod test {
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
 		let proof = {
 			// Create a prover struct
-			let mut prover = Prover::<Bn254, JubjubParameters, SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>>::new(b"anchor");
+			let mut prover = Prover::<Bn254, JubjubParameters, SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>>::new(b"vanchor");
 			prover.key_transcript(b"key", b"additional seed information");
 			// Add gadgets
 			let _ = anchor.gadget(prover.mut_cs());
@@ -697,7 +906,7 @@ mod test {
 		// Verifier's view
 
 		// Create a Verifier object
-		let mut verifier = Verifier::new(b"anchor");
+		let mut verifier = Verifier::new(b"vanchor");
 		verifier.key_transcript(b"key", b"additional seed information");
 		// Add gadgets
 		let _ = anchor.gadget(verifier.mut_cs());
@@ -760,9 +969,9 @@ mod test {
 		// Path
 		let path = tree.generate_membership_proof(last_index as u64);
 
-		// Create AnchorCircuit
+		// Create VariableAnchorCircuit
 		let mut anchor =
-			AnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE>::new(
+			VariableAnchorCircuit::<Bn254Fr, JubjubParameters, PoseidonGadget, HEIGHT, BRIDGE_SIZE, INS, OUTS>::new(
 				chain_id,
 				secret,
 				nullifier,
@@ -783,7 +992,7 @@ mod test {
 			SonicKZG10::<Bn254, DensePolynomial<Bn254Fr>>::setup(1 << 18, None, rng).unwrap();
 		let proof = {
 			// Create a prover struct
-			let mut prover = Prover::<Bn254, JubjubParameters, SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>>::new(b"anchor");
+			let mut prover = Prover::<Bn254, JubjubParameters, SonicKZG10<Bn254, DensePolynomial<Bn254Fr>>>::new(b"vanchor");
 			prover.key_transcript(b"key", b"additional seed information");
 			// Add gadgets
 			let _ = anchor.gadget(prover.mut_cs());
@@ -800,7 +1009,7 @@ mod test {
 		// Verifier's view
 
 		// Create a Verifier object
-		let mut verifier = Verifier::new(b"anchor");
+		let mut verifier = Verifier::new(b"vanchor");
 		verifier.key_transcript(b"key", b"additional seed information");
 		// Add gadgets
 		let _ = anchor.gadget(verifier.mut_cs());

--- a/arkworks-plonk-circuits/src/vanchor/mod.rs
+++ b/arkworks-plonk-circuits/src/vanchor/mod.rs
@@ -16,15 +16,13 @@
 // Then we will verify that the reconstructed root from each input's
 // membership path is within a set of public merkle roots.
 
-use std::ops::Add;
-
 use crate::{
 	merkle_tree::PathGadget, mixer::add_public_input_variable,
 	poseidon::poseidon::FieldHasherGadget, set_membership::check_set_membership_is_enabled,
 };
 use ark_ec::{models::TEModelParameters, PairingEngine};
 use ark_ff::PrimeField;
-use ark_std::{One, Zero};
+use ark_std::{vec, One, Zero};
 use arkworks_gadgets::{merkle_tree::simple_merkle::Path, poseidon::field_hasher::FieldHasher};
 use plonk_core::{
 	circuit::Circuit, constraint_system::StandardComposer, error::Error, prelude::Variable,

--- a/arkworks-plonk-circuits/src/vanchor/mod.rs
+++ b/arkworks-plonk-circuits/src/vanchor/mod.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 use ark_ec::{models::TEModelParameters, PairingEngine};
 use ark_ff::PrimeField;
-use ark_std::{vec, One, Zero};
+use ark_std::{vec::Vec, One, Zero};
 use arkworks_gadgets::{merkle_tree::simple_merkle::Path, poseidon::field_hasher::FieldHasher};
 use plonk_core::{
 	circuit::Circuit, constraint_system::StandardComposer, error::Error, prelude::Variable,
@@ -361,6 +361,8 @@ mod test {
 	// -in_root_set[0], -in_root_set[1], out_commitments[0], out_commitments[1]];
 	// ! Note that because of how check_set_membership is written the public input
 	// values are actually (-1)*root_hash, not root hash !
+
+	// TODO: Add a 16-2 test rather than making INS generic
 
 	#[test]
 	fn should_verify_correct_vanchor_plonk() {


### PR DESCRIPTION
This adds the anchor and vanchor plonk circuits to the protocol, so it closes #86 and closes #87.  

Aside from the anchor and vanchor there are a few new things:

*   I wrote a new testing helper function to replace `gadget_tester` (see [here](https://github.com/webb-tools/arkworks-gadgets/blob/2c3bef7a30bd6215cb99f976f9f4c7f2eef4deaf/arkworks-plonk-circuits/src/utils.rs#L85-L156)). The reason is that `gadget_tester` has issues with failure tests.  One thing I didn't like about `gadget_tester` was that it lacks functionality for failure tests where the prover/verifier disagree on what the public input values are.  The new `prove_then_verify` function improves on this by adding an optional `verifier_public_inputs` argument.  This is useful for testing things like `should_fail_to_verify_wrong_chain_id`, for example. 
*   Added a `check_membership_is_enabled` function to use for dummy inputs to the vanchor circuit (see [here](https://github.com/webb-tools/arkworks-gadgets/blob/2c3bef7a30bd6215cb99f976f9f4c7f2eef4deaf/arkworks-plonk-circuits/src/set_membership/mod.rs#L51-L83)). 

To-Do: the vanchor tests are still ugly and I would like to clean them up.  My main question regarding these tests is 

*   Initializing the array of `input_paths` in the obvious way would be to define some `default_path` and initialize the array as `[default_path; INS]`.  But `PathGadget`s don't implement Copy and deriving Copy doesn't seem to work.  So what I'm doing now is ugly, see [here](https://github.com/webb-tools/arkworks-gadgets/blob/2c3bef7a30bd6215cb99f976f9f4c7f2eef4deaf/arkworks-plonk-circuits/src/vanchor/mod.rs#L387-L392). 
*   At the moment I'm letting `INS = BRIDGE_SIZE` so that the root set is the same size as the number of inputs.  I don't really know what I'd do to make the tests allow for those two parameters to be unequal.  (Maybe it's not worth doing?)