### PR TITLE
update parity-scale-codec #211

### DIFF
--- a/arkworks-setups/Cargo.toml
+++ b/arkworks-setups/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arkworks-setups"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Webb protocol's API for zero-knowledge circuits"

--- a/arkworks-setups/Cargo.toml
+++ b/arkworks-setups/Cargo.toml
@@ -24,7 +24,7 @@ ark-serialize = { version = "^0.3.0", default-features = false }
 ark-groth16 = { version = "^0.3.0", default-features = false }
 
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
-codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 crypto_box = { version = "0.7.1", optional = true }
 
 [dependencies.arkworks-utils]


### PR DESCRIPTION
Ink 3.0-rc9 brought some breaking changes one of which is to  upgrade `parity-scale-codec ` to version="3".

more info about Ink! 3.0-rc9 changes : [here](https://github.com/paritytech/ink/blob/v3.0.0-rc9/RELEASES.md)

arkwork-setups had a dep `parity-scale-codec, version="2"` which started creating  multiple version conflicts in ink! smartcontracts

```
e.g
error: There are multiple `parity-scale-codec` packages in your project, and the specification `parity-scale-codec` is ambiguous.
Please re-run this command with `-p <spec>` where `<spec>` is one of the following:
  parity-scale-codec:2.3.1
  parity-scale-codec:3.1.2
```
