### PR TITLE
Switch to dtolnay rust-toolchain

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,19 +27,19 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          override: true
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v1.3.0
 
-      - name: Run Tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          args: '--workspace --release --locked --out Xml --jobs 16 --timeout 5600 -- --test-threads 16'
+      - name: Install Tarpaulin
+        run: cargo install cargo-tarpaulin
 
+      - name: Run Tarpaulin
+        run: cargo tarpaulin --workspace --release --locked --out Xml --jobs 16 --timeout 5600 -- --test-threads 16
+      
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v2
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,7 +35,7 @@ jobs:
         uses: Swatinem/rust-cache@v1.3.0
 
       - name: Install Tarpaulin
-        run: cargo install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin --locked
 
       - name: Run Tarpaulin
         run: cargo tarpaulin --workspace --release --locked --out Xml --jobs 16 --timeout 5600 -- --test-threads 16

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,10 +32,10 @@ jobs:
           toolchain: stable
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v1.3.0
+        uses: Swatinem/rust-cache@v2
 
       - name: Install Tarpaulin
-        run: cargo install cargo-tarpaulin --locked
+        run: cargo install cargo-tarpaulin
 
       - name: Run Tarpaulin
         run: cargo tarpaulin --workspace --release --locked --out Xml --jobs 16 --timeout 5600 -- --test-threads 16


### PR DESCRIPTION
**Summary of changes**
- Use [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain) instead of actions-rs/toolchain
- Use `cargo` directly instead of actions-rs/cargo


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 

-----
### Code Checklist 

- [ ] Tested
- [ ] Documented
